### PR TITLE
Support older numpy installations with PyPI wheels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,7 @@ jobs:
           name: Checkout repository
           command: |
             cd /root
+            echo ${CIRCLE_REPOSITORY_URL}
             git clone ${CIRCLE_REPOSITORY_URL} code
             cd code
             if [ -n "$CIRCLE_TAG" ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,8 +98,7 @@ jobs:
           name: Checkout repository
           command: |
             cd /root
-            echo ${CIRCLE_REPOSITORY_URL}
-            git clone ${CIRCLE_REPOSITORY_URL} code
+            git clone https://github.com/${CIRCLE_PROJECT_REPONAME} code
             cd code
             if [ -n "$CIRCLE_TAG" ]
             then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
           name: Checkout repository
           command: |
             cd /root
-            git clone https://github.com/${CIRCLE_PROJECT_REPONAME} code
+            git clone https://github.com/glotzerlab/${CIRCLE_PROJECT_REPONAME} code
             cd code
             if [ -n "$CIRCLE_TAG" ]
             then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,13 +150,12 @@ jobs:
                 "${PYBIN}/nosetests"
             done
       - run:
-          name: Test wheels (latest numpy)
+          name: Test wheels (no numpy)
           working_directory: /root/code
           command: |
             for PYBIN in /opt/python/cp35*/bin /opt/python/cp36*/bin /opt/python/cp37*/bin; do
                 echo Testing `${PYBIN}/python --version`
-                "${PYBIN}/pip" install numpy --upgrade --progress-bar=off
-                "${PYBIN}/pip" install nose --progress-bar=off
+                "${PYBIN}/pip" uninstall numpy --progress-bar=off
                 "${PYBIN}/pip" install gsd --no-index -f dist --progress-bar=off
                 "${PYBIN}/nosetests"
             done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,12 +150,12 @@ jobs:
                 "${PYBIN}/nosetests"
             done
       - run:
-          name: Test wheels (no numpy)
+          name: Test wheels (latest numpy)
           working_directory: /root/code
           command: |
             for PYBIN in /opt/python/cp35*/bin /opt/python/cp36*/bin /opt/python/cp37*/bin; do
                 echo Testing `${PYBIN}/python --version`
-                "${PYBIN}/pip" uninstall numpy
+                "${PYBIN}/pip" install numpy --update --progress-bar=off
                 "${PYBIN}/pip" install gsd --no-index -f dist --progress-bar=off
                 "${PYBIN}/nosetests"
             done
@@ -179,6 +179,8 @@ jobs:
           condition: << parameters.upload-package >>
           steps:
             - run: echo "Branch build, skipping upload"
+      - store_artifacts:
+          path: /root/code/dist
 workflows:
   test:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
             export PYBIN=/opt/python/cp37-cp37m/bin
             "${PYBIN}/python" setup.py sdist
       - when:
-          condition: << parameters.upload >>
+          condition: << parameters.upload-package >>
           steps:
             - run:
                 name: Upload
@@ -163,7 +163,7 @@ jobs:
                 command: |
                   echo "Would have uploaded..."
       - unless:
-          condition: << parameters.upload >>
+          condition: << parameters.upload-package >>
           steps:
             - run: echo "Branch build, skipping upload"
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
 
   pypi-linux-wheels:
     parameters:
-      upload:
+      upload-package:
         type: boolean
         default: false
     docker:
@@ -234,14 +234,13 @@ workflows:
           python-version: "3.5"
           cmake: /opt/cmake-2.8.12/bin/cmake
 
-      - pypi-linux-wheels:
-          upload: ""
+      - pypi-linux-wheels
 
   deploy:
     jobs:
       - pypi-linux-wheels:
           context: org-global
-          upload: true
+          upload-package: true
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,9 @@ jobs:
             - sphinx
 
   pypi-linux-wheels:
+    upload:
+      type: boolean
+      default: false
     docker:
       - image: quay.io/pypa/manylinux1_x86_64
     steps:
@@ -93,13 +96,26 @@ jobs:
       - checkout:
           path: /root/code
       - run:
-          name: Compile wheels
+          name: Build numpy
+          working_directory: /
+          command: |
+            for PYBIN in /opt/python/*/bin; do
+                echo Building numpy for `${PYBIN}/python --version`
+                "${PYBIN}/python" -m pip install --no-deps --ignore-installed -v --progress-bar=off cython
+                curl -sSLO https://github.com/numpy/numpy/archive/v1.9.3.tar.gz
+                tar -xzf v1.9.3.tar.gz
+                cd numpy-1.9.3
+                rm -f numpy/random/mtrand/mtrand.c
+                rm -f PKG-INFO
+                "${PYBIN}/python" -m pip install --no-deps --ignore-installed -v --progress-bar=off .
+            done
+      - run:
+          name: Compile gsd wheels
           working_directory: /root/code
           command: |
             for PYBIN in /opt/python/*/bin; do
-                echo Building for `${PYBIN}/python --version`
-                "${PYBIN}/pip" install numpy --progress-bar=off
-                "${PYBIN}/pip" wheel . -w wheels/ --no-deps --progress-bar=off
+                echo Building gsd for `${PYBIN}/python --version`
+                "${PYBIN}/python" -m pip wheel . -w wheels/ --no-deps --progress-bar=off
             done
       - run:
           name: Audit wheels
@@ -124,14 +140,20 @@ jobs:
           command: |
             export PYBIN=/opt/python/cp37-cp37m/bin
             "${PYBIN}/python" setup.py sdist
-      - run:
-          name: Upload
-          working_directory: /root/code
-          command: |
-            export PYBIN=/opt/python/cp37-cp37m/bin
-            "${PYBIN}/pip" install twine --progress-bar=off
-            "${PYBIN}/twine" upload --username joaander --password ${PYPI_PASSWORD} dist/*
-
+      - when:
+          condition: << parameters.upload >>
+          steps:
+            - run:
+                name: Upload
+                working_directory: /root/code
+                command: |
+                  export PYBIN=/opt/python/cp37-cp37m/bin
+                  "${PYBIN}/pip" install twine --progress-bar=off
+                  "${PYBIN}/twine" upload --username joaander --password ${PYPI_PASSWORD} dist/*
+      - unless:
+          condition: << parameters.upload >>
+          steps:
+            - run: echo "Branch build, skipping upload"
 workflows:
   test:
     jobs:
@@ -200,10 +222,14 @@ workflows:
           python-version: "3.5"
           cmake: /opt/cmake-2.8.12/bin/cmake
 
+      - pypi-linux-wheels:
+          upload: false
+
   deploy:
     jobs:
       - pypi-linux-wheels:
           context: org-global
+          upload: true
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,11 +140,22 @@ jobs:
                 auditwheel repair "$whl" -w dist/
             done
       - run:
-          name: Test wheels
+          name: Test wheels (old numpy)
           working_directory: /root/code
           command: |
             for PYBIN in /opt/python/cp35*/bin /opt/python/cp36*/bin /opt/python/cp37*/bin; do
                 echo Testing `${PYBIN}/python --version`
+                "${PYBIN}/pip" install nose --progress-bar=off
+                "${PYBIN}/pip" install gsd --no-index -f dist --progress-bar=off
+                "${PYBIN}/nosetests"
+            done
+      - run:
+          name: Test wheels (latest numpy)
+          working_directory: /root/code
+          command: |
+            for PYBIN in /opt/python/cp35*/bin /opt/python/cp36*/bin /opt/python/cp37*/bin; do
+                echo Testing `${PYBIN}/python --version`
+                "${PYBIN}/pip" install numpy --upgrade
                 "${PYBIN}/pip" install nose --progress-bar=off
                 "${PYBIN}/pip" install gsd --no-index -f dist --progress-bar=off
                 "${PYBIN}/nosetests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,9 +148,7 @@ jobs:
                 name: Upload
                 working_directory: /root/code
                 command: |
-                  export PYBIN=/opt/python/cp37-cp37m/bin
-                  "${PYBIN}/pip" install twine --progress-bar=off
-                  "${PYBIN}/twine" upload --username joaander --password ${PYPI_PASSWORD} dist/*
+                  echo "Would have uploaded..."
       - unless:
           condition: << parameters.upload >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
           name: Build numpy
           working_directory: /
           command: |
-            for PYBIN in /opt/python/cp27*/bin /opt/python/cp34*/bin /opt/python/cp36*/bin /opt/python/cp37*/bin; do
+            for PYBIN in /opt/python/cp27*/bin /opt/python/cp35*/bin /opt/python/cp36*/bin /opt/python/cp37*/bin; do
                 echo Building numpy for `${PYBIN}/python --version`
                 "${PYBIN}/python" -m pip install cython --no-deps --ignore-installed -q --progress-bar=off
                 rm -rf numpy-1.9.3
@@ -128,7 +128,7 @@ jobs:
           name: Compile gsd wheels
           working_directory: /root/code
           command: |
-            for PYBIN in /opt/python/cp27*/bin /opt/python/cp34*/bin /opt/python/cp36*/bin /opt/python/cp37*/bin; do
+            for PYBIN in /opt/python/cp27*/bin /opt/python/cp35*/bin /opt/python/cp36*/bin /opt/python/cp37*/bin; do
                 echo Building gsd for `${PYBIN}/python --version`
                 "${PYBIN}/python" -m pip wheel -w wheels/ . --no-deps --progress-bar=off --no-build-isolation --no-use-pep517
             done
@@ -143,7 +143,7 @@ jobs:
           name: Test wheels
           working_directory: /root/code
           command: |
-            for PYBIN in /opt/python/cp27*/bin /opt/python/cp34*/bin /opt/python/cp36*/bin /opt/python/cp37*/bin; do
+            for PYBIN in /opt/python/cp27*/bin /opt/python/cp35*/bin /opt/python/cp36*/bin /opt/python/cp37*/bin; do
                 echo Testing `${PYBIN}/python --version`
                 "${PYBIN}/pip" install nose --progress-bar=off
                 "${PYBIN}/pip" install gsd --no-index -f dist --progress-bar=off

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
           name: Test wheels
           working_directory: /root/code
           command: |
-            for PYBIN in /opt/python/cp27*/bin /opt/python/cp35*/bin /opt/python/cp36*/bin /opt/python/cp37*/bin; do
+            for PYBIN in /opt/python/cp35*/bin /opt/python/cp36*/bin /opt/python/cp37*/bin; do
                 echo Testing `${PYBIN}/python --version`
                 "${PYBIN}/pip" install nose --progress-bar=off
                 "${PYBIN}/pip" install gsd --no-index -f dist --progress-bar=off

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,9 +127,9 @@ jobs:
           name: Compile gsd wheels
           working_directory: /root/code
           command: |
-            for PYBIN in /opt/python/*/bin; do
+            for PYBIN in /opt/python/cp37*/bin; do
                 echo Building gsd for `${PYBIN}/python --version`
-                "${PYBIN}/python" -m pip wheel . -w wheels/ --no-deps --progress-bar=off
+                "${PYBIN}/python" -m pip wheel . -w wheels/ --no-deps --progress-bar=off -v
             done
       - run:
           name: Audit wheels

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,7 @@ jobs:
             for PYBIN in /opt/python/cp27*/bin /opt/python/cp34*/bin /opt/python/cp36*/bin /opt/python/cp37*/bin; do
                 echo Building numpy for `${PYBIN}/python --version`
                 "${PYBIN}/python" -m pip install cython --no-deps --ignore-installed -q --progress-bar=off
+                rm -rf numpy-1.9.3
                 curl -sSLO https://github.com/numpy/numpy/archive/v1.9.3.tar.gz
                 tar -xzf v1.9.3.tar.gz
                 cd numpy-1.9.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,8 +94,21 @@ jobs:
           name: Install software
           working_directory: /root/code
           command: yum install -y openssh-clients
-      - checkout:
-          path: /root/code
+      - run:
+          name: Checkout repository
+          command: |
+            cd /root
+            git clone ${CIRCLE_REPOSITORY_URL} code
+            cd code
+            if [ -n "$CIRCLE_TAG" ]
+            then
+              git reset --hard "$CIRCLE_SHA1"
+              git checkout -q "$CIRCLE_TAG"
+            elif [ -n "$CIRCLE_BRANCH" ]
+            then
+              git reset --hard "$CIRCLE_SHA1"
+              git checkout -q -B "$CIRCLE_BRANCH"
+            fi
       - run:
           name: Build numpy
           working_directory: /
@@ -222,7 +235,7 @@ workflows:
           cmake: /opt/cmake-2.8.12/bin/cmake
 
       - pypi-linux-wheels:
-          upload: false
+          upload: ""
 
   deploy:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,9 +83,10 @@ jobs:
             - sphinx
 
   pypi-linux-wheels:
-    upload:
-      type: boolean
-      default: false
+    parameters:
+      upload:
+        type: boolean
+        default: false
     docker:
       - image: quay.io/pypa/manylinux1_x86_64
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
           command: |
             for PYBIN in /opt/python/cp35*/bin /opt/python/cp36*/bin /opt/python/cp37*/bin; do
                 echo Testing `${PYBIN}/python --version`
-                "${PYBIN}/pip" install numpy --upgrade
+                "${PYBIN}/pip" install numpy --upgrade --progress-bar=off
                 "${PYBIN}/pip" install nose --progress-bar=off
                 "${PYBIN}/pip" install gsd --no-index -f dist --progress-bar=off
                 "${PYBIN}/nosetests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,10 +237,12 @@ workflows:
           cmake: /opt/cmake-2.8.12/bin/cmake
 
       - pypi-linux-wheels
+          name: wheel-build
 
   deploy:
     jobs:
       - pypi-linux-wheels:
+          name: wheel-upload
           context: org-global
           upload-package: true
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,7 @@ workflows:
           python-version: "3.5"
           cmake: /opt/cmake-2.8.12/bin/cmake
 
-      - pypi-linux-wheels
+      - pypi-linux-wheels:
           name: wheel-build
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,13 +115,13 @@ jobs:
           command: |
             for PYBIN in /opt/python/cp37*/bin; do
                 echo Building numpy for `${PYBIN}/python --version`
-                "${PYBIN}/python" -m pip install --no-deps --ignore-installed -v --progress-bar=off cython
+                "${PYBIN}/python" -m pip install --no-deps --ignore-installed -q --progress-bar=off cython
                 curl -sSLO https://github.com/numpy/numpy/archive/v1.9.3.tar.gz
                 tar -xzf v1.9.3.tar.gz
                 cd numpy-1.9.3
                 rm -f numpy/random/mtrand/mtrand.c
                 rm -f PKG-INFO
-                "${PYBIN}/python" -m pip install --no-deps --ignore-installed -v --progress-bar=off .
+                "${PYBIN}/python" -m pip install --no-deps --ignore-installed -v --progress-bar=off -q .
             done
       - run:
           name: Compile gsd wheels
@@ -129,7 +129,7 @@ jobs:
           command: |
             for PYBIN in /opt/python/cp37*/bin; do
                 echo Building gsd for `${PYBIN}/python --version`
-                "${PYBIN}/python" -m pip wheel . -w wheels/ --no-deps --progress-bar=off -v
+                "${PYBIN}/python" -m pip wheel -w wheels/ --no-deps --progress-bar=off -q --no-build-isolation --no-use-pep517 .
             done
       - run:
           name: Audit wheels

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
           command: |
             for PYBIN in /opt/python/cp35*/bin /opt/python/cp36*/bin /opt/python/cp37*/bin; do
                 echo Testing `${PYBIN}/python --version`
-                "${PYBIN}/pip" install numpy --update --progress-bar=off
+                "${PYBIN}/pip" install numpy --upgrade --progress-bar=off
                 "${PYBIN}/pip" install gsd --no-index -f dist --progress-bar=off
                 "${PYBIN}/nosetests"
             done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
           name: Build numpy
           working_directory: /
           command: |
-            for PYBIN in /opt/python/*/bin; do
+            for PYBIN in /opt/python/cp37*/bin; do
                 echo Building numpy for `${PYBIN}/python --version`
                 "${PYBIN}/python" -m pip install --no-deps --ignore-installed -v --progress-bar=off cython
                 curl -sSLO https://github.com/numpy/numpy/archive/v1.9.3.tar.gz
@@ -142,7 +142,7 @@ jobs:
           name: Test wheels
           working_directory: /root/code
           command: |
-            for PYBIN in /opt/python/cp3*/bin/; do
+            for PYBIN in /opt/python/cp37*/bin/; do
                 echo Testing `${PYBIN}/python --version`
                 "${PYBIN}/pip" install nose --progress-bar=off
                 "${PYBIN}/pip" install gsd --no-index -f dist --progress-bar=off

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,23 +113,23 @@ jobs:
           name: Build numpy
           working_directory: /
           command: |
-            for PYBIN in /opt/python/cp37*/bin; do
+            for PYBIN in /opt/python/cp27*/bin /opt/python/cp34*/bin /opt/python/cp36*/bin /opt/python/cp37*/bin; do
                 echo Building numpy for `${PYBIN}/python --version`
-                "${PYBIN}/python" -m pip install --no-deps --ignore-installed -q --progress-bar=off cython
+                "${PYBIN}/python" -m pip install cython --no-deps --ignore-installed -q --progress-bar=off
                 curl -sSLO https://github.com/numpy/numpy/archive/v1.9.3.tar.gz
                 tar -xzf v1.9.3.tar.gz
                 cd numpy-1.9.3
                 rm -f numpy/random/mtrand/mtrand.c
                 rm -f PKG-INFO
-                "${PYBIN}/python" -m pip install --no-deps --ignore-installed -v --progress-bar=off -q .
+                "${PYBIN}/python" -m pip install . --no-deps --ignore-installed -v --progress-bar=off -q
             done
       - run:
           name: Compile gsd wheels
           working_directory: /root/code
           command: |
-            for PYBIN in /opt/python/cp37*/bin; do
+            for PYBIN in /opt/python/cp27*/bin /opt/python/cp34*/bin /opt/python/cp36*/bin /opt/python/cp37*/bin; do
                 echo Building gsd for `${PYBIN}/python --version`
-                "${PYBIN}/python" -m pip wheel -w wheels/ --no-deps --progress-bar=off -q --no-build-isolation --no-use-pep517 .
+                "${PYBIN}/python" -m pip wheel -w wheels/ . --no-deps --progress-bar=off --no-build-isolation --no-use-pep517
             done
       - run:
           name: Audit wheels
@@ -142,7 +142,7 @@ jobs:
           name: Test wheels
           working_directory: /root/code
           command: |
-            for PYBIN in /opt/python/cp37*/bin/; do
+            for PYBIN in /opt/python/cp27*/bin /opt/python/cp34*/bin /opt/python/cp36*/bin /opt/python/cp37*/bin; do
                 echo Testing `${PYBIN}/python --version`
                 "${PYBIN}/pip" install nose --progress-bar=off
                 "${PYBIN}/pip" install gsd --no-index -f dist --progress-bar=off

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,9 @@ jobs:
                 name: Upload
                 working_directory: /root/code
                 command: |
-                  echo "Would have uploaded..."
+                  export PYBIN=/opt/python/cp37-cp37m/bin
+                  "${PYBIN}/pip" install twine --progress-bar=off
+                  "${PYBIN}/twine" upload --username joaander --password ${PYPI_PASSWORD} dist/*
       - unless:
           condition: << parameters.upload-package >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
           command: |
             for PYBIN in /opt/python/cp35*/bin /opt/python/cp36*/bin /opt/python/cp37*/bin; do
                 echo Testing `${PYBIN}/python --version`
-                "${PYBIN}/pip" uninstall numpy --progress-bar=off
+                "${PYBIN}/pip" uninstall numpy
                 "${PYBIN}/pip" install gsd --no-index -f dist --progress-bar=off
                 "${PYBIN}/nosetests"
             done

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,11 @@ Change Log
 
 `gsd <https://github.com/glotzerlab/gsd>`_ releases follow `semantic versioning <https://semver.org/>`_.
 
+v1.6.2 (not yetreleased)
+------------------------
+
+* PyPI binary wheels now support numpy>=1.9.3,<2
+
 v1.6.1 (2019-03-05)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(name = 'gsd',
             "Topic :: Scientific/Engineering :: Physics",
         ],
 
-      install_requires=['numpy'],
+      install_requires=['numpy>=1.9.3,<2'],
       ext_modules = [fl],
       packages = ['gsd']
      )


### PR DESCRIPTION
Build with numpy 1.9.3 for PyPI wheels to support a large number of users. Also specify this requirement in setup.py `install_requires` to ensure that users installing gsd get a compatible version of numpy. This requirement is not necessary when building from source, but PyPI doesn't provide any mechanism that I am aware of to separately specify wheel and package dependencies. See #23 for further discussion.