### PR TITLE
Feature/hoomd trajectory view

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@ Change Log
 
 `gsd <https://github.com/glotzerlab/gsd>`_ releases follow `semantic versioning <https://semver.org/>`_.
 
+next
+----
+
+* Slicing a HOOMDTrajectory object returns a view that can be used to directly select frames from a subset
+  or sliced again.
+
 v1.7.0 (2019-04-30)
 -------------------
 

--- a/doc/hoomd-examples.rst
+++ b/doc/hoomd-examples.rst
@@ -46,8 +46,8 @@ Append frames to a gsd file
 
     t = gsd.hoomd.open(name='test.gsd', mode='wb')
     t.extend( (create_frame(i) for i in range(10)) )
-    t.append( create_frame(11) )
-    # length is 12 because extend added 10, and append added 1
+    t.append( create_frame(10) )
+    # length is 11 because extend() added 10, and append() added 1
     len(t)
 
 Use :py:func:`gsd.hoomd.open` to open a GSD file with the high level interface

--- a/doc/hoomd-examples.rst
+++ b/doc/hoomd-examples.rst
@@ -92,7 +92,7 @@ works like expected:
     print('last step', t[-1].configuration.step, end=' ')
 
     every_2nd_frame = t[::2]  # create a view of a trajectory subset
-    for s in every_2nd_frame[:10]:
+    for s in every_2nd_frame[:4]:
         print(s.configuration.step, end=' ')
 
 Slicing a trajectory creates a trajectory view, which can then be queried for

--- a/doc/hoomd-examples.rst
+++ b/doc/hoomd-examples.rst
@@ -76,16 +76,29 @@ Randomly index frames
 :py:class:`gsd.hoomd.HOOMDTrajectory` supports random indexing of frames in the file. Indexing
 into a trajectory returns a :py:class:`gsd.hoomd.Snapshot`.
 
-Slicing
-^^^^^^^
+Slicing and selection
+^^^^^^^^^^^^^^^^^^^^^
+
+Use the slicing operator to select individual frames or a subset of a trajectory
+works like expected:
 
 .. ipython:: python
 
     t = gsd.hoomd.open(name='test.gsd', mode='rb')
+
     for s in t[5:-2]:
         print(s.configuration.step, end=' ')
 
-Slicing access works like you would expect it to.
+    print('last step', t[-1].configuration.step, end=' ')
+
+    every_2nd_frame = t[::2]  # create a view of a trajectory subset
+    for s in every_2nd_frame[:10]:
+        print(s.configuration.step, end=' ')
+
+Slicing a trajectory creates a trajectory view, which can then be queried for
+length or sliced again.
+Selecting individual frames from a view works exactly like selecting individual
+frames from the original trajectory object.
 
 Pure python reader
 ^^^^^^^^^^^^^^^^^^

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -467,6 +467,31 @@ class _HOOMDTrajectoryIterable(object):
     def __len__(self):
         return len(self._indices)
 
+
+class _HOOMDTrajectoryView(object):
+    """A view of a HOOMDTrajectory object.
+
+    Enables the slicing and iteration over a subset of a trajectory
+    instance.
+    """
+
+    def __init__(self, trajectory, indices):
+        self._trajectory = trajectory
+        self._indices = indices
+
+    def __iter__(self):
+        return _HOOMDTrajectoryIterable(self._trajectory, self._indices)
+
+    def __len__(self):
+        return len(self._indices)
+
+    def __getitem__(self, key):
+        if isinstance(key, slice):
+            return type(self)(self._trajectory, self._indices[key])
+        else:
+            return self._trajectory[self._indices[key]]
+
+
 class HOOMDTrajectory(object):
     """ Read and write hoomd gsd files.
 
@@ -718,7 +743,7 @@ class HOOMDTrajectory(object):
         """
 
         if isinstance(key, slice) :
-            return _HOOMDTrajectoryIterable(self, range(*key.indices(len(self))))
+            return _HOOMDTrajectoryView(self, range(*key.indices(len(self))))
         elif isinstance(key, int) :
             if key < 0:
                 key += len(self)

--- a/tests/test_hoomd.py
+++ b/tests/test_hoomd.py
@@ -423,6 +423,59 @@ def test_slicing_and_iteration():
             eq_(len(list(hf_iter)), 10)
             eq_(len(list(hf_iter)), 10)
 
+            # Test frame selection
+            with assert_raises(IndexError):
+                hf[len(hf)]
+            eq_(hf[0].configuration.step, hf[0].configuration.step)
+            eq_(hf[len(hf) - 1].configuration.step, hf[-1].configuration.step)
+
+
+def test_view_slicing_and_iteration():
+    with tempfile.TemporaryDirectory() as d:
+
+        with gsd.hoomd.open(name=d+"/test_slicing.gsd", mode='wb') as hf:
+            hf.extend((create_frame(i) for i in range(40)));
+
+        with gsd.hoomd.open(name=d+"/test_slicing.gsd", mode='rb') as hf:
+            view = hf[::2]
+
+            # Test len()-function on trajectory and sliced view.
+            eq_(len(view), 20)
+            eq_(len(view[:10]), 10)
+            eq_(len(view[::2]), 10)
+
+            # Test len()-function with explicit iterator.
+            eq_(len(iter(view)), len(view))
+            eq_(len(iter(view[:10])), len(view[:10]))
+
+            # Test iteration with implicit iterator.
+            # All iterations are run twice to check for issues
+            # with iterator exhaustion.
+            eq_(len(list(view)), len(view))
+            eq_(len(list(view)), len(view))
+            eq_(len(list(view[:10])), len(view[:10]))
+            eq_(len(list(view[:10])), len(view[:10]))
+            eq_(len(list(view[::2])), len(view[::2]))
+            eq_(len(list(view[::2])), len(view[::2]))
+
+            # Test iteration with explicit iterator.
+            view_iter = iter(view)
+            eq_(len(view_iter), len(view))  # sanity check
+            eq_(len(list(view_iter)), len(view))
+            eq_(len(list(view_iter)), len(view))
+
+            # Test iteration with explicit sliced iterator.
+            view_iter = iter(view[:10])
+            eq_(len(view_iter), 10)  # sanity check
+            eq_(len(list(view_iter)), 10)
+            eq_(len(list(view_iter)), 10)
+
+            # Test frame selection
+            with assert_raises(IndexError):
+                view[len(view)]
+            eq_(view[0].configuration.step, view[0].configuration.step)
+            eq_(view[len(view) - 1].configuration.step, view[-1].configuration.step)
+
 def test_truncate():
     with tempfile.TemporaryDirectory() as d:
         gsd.hoomd.create(name=d+"/test_iteration.gsd");


### PR DESCRIPTION
Implement _HOOMDTrajectoryView class.

This patch modifies the HOOMDTrajectory class to return a view after
slicing instead of an iterable. A view represents a subset of a
trajectory that can still be queried for length, iterated over or, and
that is the key point of this, used for invididual frame selection or
sliced again.

For example:

```python
with gsd.hoomd.open('trajectory.gsd') as traj:
    # Select subset (every 10th frame):
    view = traj[::10]

    # This was already possible prior to this patch:
    for frame in view:
        pass

    # But now we can also select frames from a view:
    n_th_frame = view[n]

    # And slice it again:
    for frame in view[:10]:
        pass
```

A sliced trajectory view returns a new view of the trajectory, similar
to a numpy array view.