### PR TITLE
more error handling for read_frame

### DIFF
--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -747,7 +747,7 @@ class HOOMDTrajectory(object):
         elif isinstance(key, int) :
             if key < 0:
                 key += len(self)
-            if key >= len(self):
+            if key >= len(self) or key < -len(self):
                 raise IndexError();
             return self.read_frame(key);
         else:

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -635,7 +635,7 @@ class HOOMDTrajectory(object):
         any default data as non-writable numpy arrays.
         """
 
-        if -len(self) > idx or idx >= len(self):
+        if idx >= len(self):
             raise IndexError;
 
         logger.debug('reading frame ' + str(idx) + ' from: ' + str(self.file));


### PR DESCRIPTION
Added error handling for indexing error for negative values. Behavior before would return a snapshot object given an out-of-bounds negative frame number, and I'm not sure what frame it would be from.