### PR TITLE
Add shape specification.

### DIFF
--- a/doc/schema-hoomd.rst
+++ b/doc/schema-hoomd.rst
@@ -58,6 +58,7 @@ Name                              Category  Type   Size Default Units
 :chunk:`particles/N`              attribute uint32 1x1  0       number
 :chunk:`particles/types`          attribute int8   NTxM ['A']   UTF-8
 :chunk:`particles/typeid`         attribute uint32 Nx1  0       number
+:chunk:`particles/type_shapes`    attribute int8   NTx1         UTF-8
 :chunk:`particles/mass`           attribute float  Nx1  1.0     mass
 :chunk:`particles/charge`         attribute float  Nx1  0.0     charge
 :chunk:`particles/diameter`       attribute float  Nx1  1.0     length
@@ -173,6 +174,19 @@ Attributes
 
     Store the type id of each particle. All id's must be less than *NT*. A particle with
     type *id* has a type name matching the corresponding row in :chunk:`particles/types`.
+
+.. chunk:: particles/type_shapes
+
+    :Type: int8
+    :Size: NTxM
+    :Default: *empty*
+    :Units: UTF-8
+
+    Store a per-type shape definition for visualization. A dictionary is stored
+    for each of the *NT* types, corresponding to a shape for visualization of
+    that type. *M* must be large enough to accommodate the shape definition as
+    a null-terminated UTF-8 JSON-encoded string. See: :ref:`shapes` for
+    examples.
 
 .. chunk:: particles/mass
 

--- a/doc/schema-hoomd.rst
+++ b/doc/schema-hoomd.rst
@@ -58,7 +58,7 @@ Name                              Category  Type   Size Default Units
 :chunk:`particles/N`              attribute uint32 1x1  0       number
 :chunk:`particles/types`          attribute int8   NTxM ['A']   UTF-8
 :chunk:`particles/typeid`         attribute uint32 Nx1  0       number
-:chunk:`particles/type_shapes`    attribute int8   NTx1         UTF-8
+:chunk:`particles/type_shapes`    attribute int8   NTxM         UTF-8
 :chunk:`particles/mass`           attribute float  Nx1  1.0     mass
 :chunk:`particles/charge`         attribute float  Nx1  0.0     charge
 :chunk:`particles/diameter`       attribute float  Nx1  1.0     length

--- a/doc/shapes.rst
+++ b/doc/shapes.rst
@@ -10,11 +10,6 @@ The class of a shape is defined by the ``type`` key.
 All other keys define properties of that shape.
 Keys without a default value are required for a valid shape specification.
 
-.. todo::
-    - Spheres specify diameters but ellipsoids specify radii
-    - Is it weird that only spheres infer their dimensionality?
-    - Ellipses in 2d?
-
 Empty (Undefined) Shape
 -----------------------
 
@@ -35,7 +30,7 @@ Spheres' dimensionality (2D circles or 3D spheres) can be inferred from the syst
 =============== =============== ====== ==== ======= ======
 Key             Description     Type   Size Default Units
 =============== =============== ====== ==== ======= ======
-diameter        Sphere diameter float  1x1  1.0     length
+diameter        Sphere diameter float  1x1          length
 
 Example::
 
@@ -54,9 +49,9 @@ The ellipsoid class has principal axes a, b, c corresponding to its radii in the
 =============== ===================== ====== ==== ======= ======
 Key             Description           Type   Size Default Units
 =============== ===================== ====== ==== ======= ======
-a               Radius in x direction float  1x1  0.5     length
-b               Radius in y direction float  1x1  0.5     length
-c               Radius in z direction float  1x1  0.5     length
+a               Radius in x direction float  1x1          length
+b               Radius in y direction float  1x1          length
+c               Radius in z direction float  1x1          length
 
 Example::
 
@@ -72,8 +67,8 @@ Polygons
 
 Type: ``Polygon``
 
+A simple polygon with its vertices specified in a counterclockwise order.
 Spheropolygons can be represented using this shape type, through the ``rounding_radius`` key.
-Vertices must be specified in a counterclockwise order.
 
 =============== =============== ===== ==== ======= ======
 Key             Description     Type  Size Default Units
@@ -94,6 +89,7 @@ Convex Polyhedra
 
 Type: ``ConvexPolyhedron``
 
+A convex polyhedron with vertices specifying the convex hull of the shape.
 Spheropolyhedra can be represented using this shape type, through the ``rounding_radius`` key.
 
 =============== =============== ===== ==== ======= ======

--- a/doc/shapes.rst
+++ b/doc/shapes.rst
@@ -1,0 +1,135 @@
+.. Copyright (c) 2016-2019 The Regents of the University of Michigan
+.. This file is part of the General Simulation Data (GSD) project, released under the BSD 2-Clause License.
+
+Shape Visualization Specification
+=================================
+
+Shape specifications contain information about the shape of individual particles.
+Each particle type stores a JSON-compatible string representation of a key-value dictionary.
+The class of a shape is defined by the ``type`` key.
+All other keys define properties of that shape.
+Keys without a default value are required for a valid shape specification.
+
+.. todo::
+    - Spheres specify diameters but ellipsoids specify radii
+    - Is it weird that only spheres infer their dimensionality?
+    - Ellipses in 2d?
+
+Empty (Undefined) Shape
+-----------------------
+
+A null string or empty dictionary can be used for undefined shapes.
+A visualization application may choose how to interpret this, e.g. by drawing nothing or drawing spheres.
+
+Example::
+
+    {}
+
+Spheres
+-------
+
+Type: ``Sphere``
+
+Spheres' dimensionality (2D circles or 3D spheres) can be inferred from the system box dimensionality.
+
+=============== =============== ====== ==== ======= ======
+Key             Description     Type   Size Default Units
+=============== =============== ====== ==== ======= ======
+diameter        Sphere diameter float  1x1  1.0     length
+
+Example::
+
+    {
+        'type': 'Sphere',
+        'diameter': 2.0
+    }
+
+Ellipsoids
+----------
+
+Type: ``Ellipsoid``
+
+The ellipsoid class has principal axes a, b, c corresponding to its radii in the x, y, and z directions.
+
+=============== ===================== ====== ==== ======= ======
+Key             Description           Type   Size Default Units
+=============== ===================== ====== ==== ======= ======
+a               Radius in x direction float  1x1  0.5     length
+b               Radius in y direction float  1x1  0.5     length
+c               Radius in z direction float  1x1  0.5     length
+
+Example::
+
+    {
+        'type': 'Ellipsoid',
+        'a': 7.0,
+        'b': 5.0,
+        'c': 3.0
+    }
+
+Polygons
+--------
+
+Type: ``Polygon``
+
+Spheropolygons can be represented using this shape type, through the ``rounding_radius`` key.
+Vertices must be specified in a counterclockwise order.
+
+=============== =============== ===== ==== ======= ======
+Key             Description     Type  Size Default Units
+=============== =============== ===== ==== ======= ======
+rounding_radius Rounding radius float 1x1  0.0     length
+vertices        Shape vertices  float Nx2          length
+
+Example::
+
+    {
+        'type': 'Polygon',
+        'rounding_radius': 0.1,
+        'vertices': [[-0.5, -0.5], [0.5, -0.5], [0.5, 0.5]]
+    }
+
+Convex Polyhedra
+----------------
+
+Type: ``ConvexPolyhedron``
+
+Spheropolyhedra can be represented using this shape type, through the ``rounding_radius`` key.
+
+=============== =============== ===== ==== ======= ======
+Key             Description     Type  Size Default Units
+=============== =============== ===== ==== ======= ======
+rounding_radius Rounding radius float 1x1  0.0     length
+vertices        Shape vertices  float Nx3          length
+
+Example::
+
+    {
+        'type': 'ConvexPolyhedron',
+        'rounding_radius': 0.1,
+        'vertices': [[0.5, 0.5, 0.5], [0.5, -0.5, -0.5], [-0.5, 0.5, -0.5], [-0.5, -0.5, 0.5]]
+    }
+
+General 3D Meshes
+-----------------
+
+Type: ``Mesh``
+
+A list of lists of indices are used to specify faces.
+Faces must contain 3 or more vertex indices.
+Faces must be defined with a counterclockwise winding order (to produce an "outward" normal).
+
+=============== =============== ====== ==== ======= ======
+Key             Description     Type   Size Default Units
+=============== =============== ====== ==== ======= ======
+vertices        Rounding radius float  Nx3          length
+indices         Rounding radius uint32              number
+
+
+Example::
+
+    {
+        'type': 'Mesh',
+        'vertices': [[0.5, 0.5, 0.5], [0.5, -0.5, -0.5], [-0.5, 0.5, -0.5], [-0.5, -0.5, 0.5]],
+        'indices': [[1, 2, 3], [1, 4, 2], [1, 3, 4], [2, 4, 3]]
+    }

--- a/doc/shapes.rst
+++ b/doc/shapes.rst
@@ -38,8 +38,8 @@ diameter        Sphere diameter float  1x1          length
 Example::
 
     {
-        'type': 'Sphere',
-        'diameter': 2.0
+        "type": "Sphere",
+        "diameter": 2.0
     }
 
 Ellipsoids
@@ -60,10 +60,10 @@ c               Radius in z direction float  1x1          length
 Example::
 
     {
-        'type': 'Ellipsoid',
-        'a': 7.0,
-        'b': 5.0,
-        'c': 3.0
+        "type": "Ellipsoid",
+        "a": 7.0,
+        "b": 5.0,
+        "c": 3.0
     }
 
 Polygons
@@ -84,9 +84,9 @@ vertices        Shape vertices  float Nx2          length
 Example::
 
     {
-        'type': 'Polygon',
-        'rounding_radius': 0.1,
-        'vertices': [[-0.5, -0.5], [0.5, -0.5], [0.5, 0.5]]
+        "type": "Polygon",
+        "rounding_radius": 0.1,
+        "vertices": [[-0.5, -0.5], [0.5, -0.5], [0.5, 0.5]]
     }
 
 Convex Polyhedra
@@ -107,9 +107,9 @@ vertices        Shape vertices  float Nx3          length
 Example::
 
     {
-        'type': 'ConvexPolyhedron',
-        'rounding_radius': 0.1,
-        'vertices': [[0.5, 0.5, 0.5], [0.5, -0.5, -0.5], [-0.5, 0.5, -0.5], [-0.5, -0.5, 0.5]]
+        "type": "ConvexPolyhedron",
+        "rounding_radius": 0.1,
+        "vertices": [[0.5, 0.5, 0.5], [0.5, -0.5, -0.5], [-0.5, 0.5, -0.5], [-0.5, -0.5, 0.5]]
     }
 
 General 3D Meshes
@@ -132,7 +132,7 @@ indices         Rounding radius uint32              number
 Example::
 
     {
-        'type': 'Mesh',
-        'vertices': [[0.5, 0.5, 0.5], [0.5, -0.5, -0.5], [-0.5, 0.5, -0.5], [-0.5, -0.5, 0.5]],
-        'indices': [[1, 2, 3], [1, 4, 2], [1, 3, 4], [2, 4, 3]]
+        "type": "Mesh",
+        "vertices": [[0.5, 0.5, 0.5], [0.5, -0.5, -0.5], [-0.5, 0.5, -0.5], [-0.5, -0.5, 0.5]],
+        "indices": [[1, 2, 3], [1, 4, 2], [1, 3, 4], [2, 4, 3]]
     }

--- a/doc/shapes.rst
+++ b/doc/shapes.rst
@@ -31,6 +31,7 @@ Spheres' dimensionality (2D circles or 3D spheres) can be inferred from the syst
 Key             Description     Type   Size Default Units
 =============== =============== ====== ==== ======= ======
 diameter        Sphere diameter float  1x1          length
+=============== =============== ====== ==== ======= ======
 
 Example::
 
@@ -52,6 +53,7 @@ Key             Description           Type   Size Default Units
 a               Radius in x direction float  1x1          length
 b               Radius in y direction float  1x1          length
 c               Radius in z direction float  1x1          length
+=============== ===================== ====== ==== ======= ======
 
 Example::
 
@@ -75,6 +77,7 @@ Key             Description     Type  Size Default Units
 =============== =============== ===== ==== ======= ======
 rounding_radius Rounding radius float 1x1  0.0     length
 vertices        Shape vertices  float Nx2          length
+=============== =============== ===== ==== ======= ======
 
 Example::
 
@@ -97,6 +100,7 @@ Key             Description     Type  Size Default Units
 =============== =============== ===== ==== ======= ======
 rounding_radius Rounding radius float 1x1  0.0     length
 vertices        Shape vertices  float Nx3          length
+=============== =============== ===== ==== ======= ======
 
 Example::
 
@@ -120,6 +124,7 @@ Key             Description     Type   Size Default Units
 =============== =============== ====== ==== ======= ======
 vertices        Rounding radius float  Nx3          length
 indices         Rounding radius uint32              number
+=============== =============== ====== ==== ======= ======
 
 
 Example::

--- a/doc/shapes.rst
+++ b/doc/shapes.rst
@@ -1,6 +1,8 @@
 .. Copyright (c) 2016-2019 The Regents of the University of Michigan
 .. This file is part of the General Simulation Data (GSD) project, released under the BSD 2-Clause License.
 
+.. _shapes:
+
 Shape Visualization Specification
 =================================
 

--- a/doc/shapes.rst
+++ b/doc/shapes.rst
@@ -6,8 +6,8 @@
 Shape Visualization Specification
 =================================
 
-Shape specifications contain information about the shape of individual particles.
-Each particle type stores a JSON-compatible string representation of a key-value dictionary.
+The chunk :chunk:`particles/type_shapes` stores information about shapes corresponding to particle types.
+Shape definitions are stored for each type as a UTF-8 encoded JSON string containing key-value pairs.
 The class of a shape is defined by the ``type`` key.
 All other keys define properties of that shape.
 Keys without a default value are required for a valid shape specification.
@@ -15,7 +15,7 @@ Keys without a default value are required for a valid shape specification.
 Empty (Undefined) Shape
 -----------------------
 
-A null string or empty dictionary can be used for undefined shapes.
+An empty dictionary can be used for undefined shapes.
 A visualization application may choose how to interpret this, e.g. by drawing nothing or drawing spheres.
 
 Example::

--- a/doc/specification.rst
+++ b/doc/specification.rst
@@ -8,3 +8,4 @@ Specification
 
     file-layer
     schema-hoomd
+    shapes

--- a/tests/test_hoomd.py
+++ b/tests/test_hoomd.py
@@ -59,6 +59,7 @@ def test_defaults(tmp_path):
         numpy.testing.assert_array_equal(s.configuration.box, numpy.array([1,1,1,0,0,0], dtype=numpy.float32));
         assert s.particles.N == 2;
         assert s.particles.types == ['A'];
+        assert s.particles.type_shapes == [{}];
         numpy.testing.assert_array_equal(s.particles.typeid, numpy.array([0,0], dtype=numpy.uint32));
         numpy.testing.assert_array_equal(s.particles.mass, numpy.array([1,1], dtype=numpy.float32));
         numpy.testing.assert_array_equal(s.particles.diameter, numpy.array([1,1], dtype=numpy.float32));
@@ -109,6 +110,10 @@ def test_fallback(tmp_path):
     snap0.configuration.box = [4,5,6,1.0,0.5,0.25];
     snap0.particles.N = 2;
     snap0.particles.types = ['A', 'B', 'C']
+    snap0.particles.type_shapes = [
+        {"type": "Sphere", "diameter": 2.0},
+        {"type": "Sphere", "diameter": 3.0},
+        {"type": "Sphere", "diameter": 4.0}]
     snap0.particles.typeid = [1,2];
     snap0.particles.mass = [2,3];
     snap0.particles.diameter = [3,4];
@@ -157,6 +162,7 @@ def test_fallback(tmp_path):
     snap2 = gsd.hoomd.Snapshot();
     snap2.particles.N = 3;
     snap2.particles.types = ['q', 's'];
+    snap2.particles.type_shapes = [{}, {}]
     snap2.bonds.N = 3;
     snap2.angles.N = 4;
     snap2.dihedrals.N = 5;
@@ -176,6 +182,7 @@ def test_fallback(tmp_path):
         numpy.testing.assert_array_equal(s.configuration.box, snap0.configuration.box);
         assert s.particles.N == snap0.particles.N;
         assert s.particles.types == snap0.particles.types;
+        assert s.particles.type_shapes == snap0.particles.type_shapes;
         numpy.testing.assert_array_equal(s.particles.typeid, snap0.particles.typeid);
         numpy.testing.assert_array_equal(s.particles.mass, snap0.particles.mass);
         numpy.testing.assert_array_equal(s.particles.diameter, snap0.particles.diameter);
@@ -225,6 +232,7 @@ def test_fallback(tmp_path):
         numpy.testing.assert_array_equal(s.configuration.box, snap0.configuration.box);
         assert s.particles.N == snap0.particles.N;
         assert s.particles.types == snap0.particles.types;
+        assert s.particles.type_shapes == snap0.particles.type_shapes;
         numpy.testing.assert_array_equal(s.particles.typeid, snap0.particles.typeid);
         numpy.testing.assert_array_equal(s.particles.mass, snap0.particles.mass);
         numpy.testing.assert_array_equal(s.particles.diameter, snap0.particles.diameter);
@@ -271,6 +279,7 @@ def test_fallback(tmp_path):
 
         assert s.particles.N == 3;
         assert s.particles.types == ['q', 's'];
+        assert s.particles.type_shapes == [{}, {}];
         numpy.testing.assert_array_equal(s.particles.typeid, numpy.array([0,0,0], dtype=numpy.uint32));
         numpy.testing.assert_array_equal(s.particles.mass, numpy.array([1,1,1], dtype=numpy.float32));
         numpy.testing.assert_array_equal(s.particles.diameter, numpy.array([1,1,1], dtype=numpy.float32));

--- a/tests/test_hoomd.py
+++ b/tests/test_hoomd.py
@@ -162,7 +162,8 @@ def test_fallback(tmp_path):
     snap2 = gsd.hoomd.Snapshot();
     snap2.particles.N = 3;
     snap2.particles.types = ['q', 's'];
-    snap2.particles.type_shapes = [{}, {}]
+    snap2.particles.type_shapes = \
+        [{}, {"type": "Ellipsoid", "a": 7.0, "b": 5.0, "c": 3.0}];
     snap2.bonds.N = 3;
     snap2.angles.N = 4;
     snap2.dihedrals.N = 5;
@@ -279,7 +280,7 @@ def test_fallback(tmp_path):
 
         assert s.particles.N == 3;
         assert s.particles.types == ['q', 's'];
-        assert s.particles.type_shapes == [{}, {}];
+        assert s.particles.type_shapes == snap2.particles.type_shapes;
         numpy.testing.assert_array_equal(s.particles.typeid, numpy.array([0,0,0], dtype=numpy.uint32));
         numpy.testing.assert_array_equal(s.particles.mass, numpy.array([1,1,1], dtype=numpy.float32));
         numpy.testing.assert_array_equal(s.particles.diameter, numpy.array([1,1,1], dtype=numpy.float32));


### PR DESCRIPTION
## Description

This PR adds a draft specification for per-type shape visualization metadata.

## Motivation and Context

Enabling shape visualization metadata is helpful for simplifying data pipelines from simulation to visualization. By providing an optional shape definition, HOOMD users can save shape information at runtime for consumption by a visualization tool. We hope to enable support for automatic shape visualization in OVITO.

## How Has This Been Tested?
Need to write tests:
- [x] Read/write empty shapes `{}`
- [x] Read/write spheres (or any non-empty shape, since they're just JSON dictionaries)
- [x] Read/write shapes changing over frames

## Change log

```
Added specification for shape visualization.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/gsd/blob/master/doc/credits.rst).