### PR TITLE
Require python 3.5+

### DIFF
--- a/gsd/__init__.py
+++ b/gsd/__init__.py
@@ -15,4 +15,8 @@ Attributes:
                        not the file layer version it reads/writes.
 """
 
+import sys
+if sys.version_info < (3, 5) or sys.version_info >= (4, 0):
+    raise RuntimeError("Python ~= 3.5 is required")
+
 __version__ = "1.8.0";

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(name = 'gsd',
         ],
 
       install_requires=['numpy>=1.9.3,<2'],
+      python_requires='~=3.5',
       ext_modules = [fl],
       packages = ['gsd']
      )


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Raise an error when used with incompatible python versions. Also attempt to correctly specify python requirements in setup.py metadata.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
v1.8.0 provides non-intuitive error messages when users install it in an unsupported python 2.7 environment.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested locally by temporarily changing the condition for python version requirements. I do not now how to test that `python_requires` actually does something.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/gsd/blob/master/doc/credits.rst).
