### PR TITLE
Support recent versions of pytest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
       python-version:
         type: string
     docker:
-      - image: glotzerlab/ci:2019.06-<< parameters.image >>
+      - image: glotzerlab/ci:2019.08-<< parameters.image >>
     environment:
       PYTHONPATH: /home/ci/project/build
       PYTHON: "/usr/bin/python<< parameters.python-version >>"
@@ -29,7 +29,7 @@ commands:
           path: code
       - run:
           name: Configure
-          command: export CC=<< parameters.cc >> CXX=<< parameters.cxx >> && mkdir build && cd build && << parameters.cmake >> ../code -DPYTHON_EXECUTABLE=${PYTHON} -DCYTHON_EXECUTABLE=`which cython3` -GNinja
+          command: export CC=<< parameters.cc >> CXX=<< parameters.cxx >> && mkdir build && cd build && << parameters.cmake >> ../code -DPYTHON_EXECUTABLE=${PYTHON} -GNinja
       - run:
           name: Compile
           command: cd build && ninja -j2
@@ -131,6 +131,14 @@ jobs:
             rm -f PKG-INFO
             "${PYBIN}/python" -m pip install . --no-deps --ignore-installed -v --progress-bar=off -q
       - run:
+          name: Cythonize code
+          working_directory: /root/code
+          command: |
+            "${PYBIN}/pip" install cython --progress-bar=off
+            cd gsd
+            ${PYBIN}/python -m cython -3 -I . fl.pyx -o fl.c
+            sha256sum fl.pyx | awk '{ print $1 }' > fl.pyx.sha256
+      - run:
           name: Compile gsd wheels
           working_directory: /root/code
           command: |
@@ -149,16 +157,16 @@ jobs:
                 name: Test wheels (old numpy)
                 working_directory: /root/code
                 command: |
-                  "${PYBIN}/pip" install nose --progress-bar=off
+                  "${PYBIN}/pip" install pytest --progress-bar=off
                   "${PYBIN}/pip" install gsd --no-index -f dist --progress-bar=off
-                  "${PYBIN}/nosetests"
+                  "${PYBIN}/pytest"
             - run:
                 name: Test wheels (latest numpy)
                 working_directory: /root/code
                 command: |
                   "${PYBIN}/pip" install numpy --upgrade --progress-bar=off
                   "${PYBIN}/pip" install gsd --no-index -f dist --progress-bar=off
-                  "${PYBIN}/nosetests"
+                  "${PYBIN}/pytest"
       - when:
           condition: << parameters.build-sdist >>
           steps:

--- a/CMake/PythonSetup.cmake
+++ b/CMake/PythonSetup.cmake
@@ -85,7 +85,7 @@ include_directories(${NUMPY_INCLUDE_DIR})
 
 #############################################################################################
 # Find cython
-find_program(CYTHON_EXECUTABLE NAMES cython)
+find_program(CYTHON_EXECUTABLE NAMES cython cython3)
 mark_as_advanced(CYTHON_EXECUTABLE)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(cython DEFAULT_MSG CYTHON_EXECUTABLE)
 

--- a/INSTALLING.rst
+++ b/INSTALLING.rst
@@ -83,7 +83,7 @@ Install Prerequisites
 
 Additional packages may be needed:
 
-* nose (unit tests)
+* pytest >= 3.9.0 (unit tests)
 * sphinx (documentation)
 * ipython (documentation)
 * an internet connection (documentation)
@@ -94,7 +94,7 @@ Install these tools with your system or virtual environment package manager. GSD
 ``pacman`` (`arch linux <https://www.archlinux.org/>`_), ``apt-get`` (`ubuntu <https://ubuntu.com/>`_), `Homebrew
 <https://brew.sh/>`_ (macOS), and `MacPorts <https://www.macports.org/>`_ (macOS)::
 
-    ▶ your-package-manager install ipython python python-nose python-numpy cmake cython python-sphinx python-sphinx_rtd_theme
+    ▶ your-package-manager install ipython python python-pytest python-numpy cmake cython python-sphinx python-sphinx_rtd_theme
 
 Typical HPC cluster environments provide python, numpy, and cmake via a module system::
 
@@ -141,13 +141,13 @@ Add the build directory path to your ``PYTHONPATH`` to test **GSD**:
 Run tests
 ^^^^^^^^^
 
-Run ``nosetests`` in the source directory to execute all unit tests. This requires that the
-python module is on the python path.
+Run ``pytest`` in the source directory to execute all unit tests. This requires that the
+compiled python module is on the python path.
 
 .. code-block:: bash
 
    ▶ cd /path/to/gsd
-   ▶ nosetests
+   ▶ pytest
 
 Build user documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ image: Visual Studio 2015
 
 environment:
   PYTHONPATH: c:\projects\gsd\build
-  CONDA:
+  PATH: 'C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%'
 
 platform:
   - x64
@@ -14,14 +14,14 @@ platform:
 configuration: Release
 
 install:
-  - ps: C:\Miniconda35-x64\Scripts\conda install -q -y numpy cython nose
+  - ps: python -m pip --disable-pip-version-check install numpy cython pytest
 
 before_build:
   - ps: mkdir build
   - ps: cd build
-  - ps: cmake ../ -G "Visual Studio 14 2015 Win64" -DPYTHON_EXECUTABLE=C:\Miniconda35-x64\python
+  - ps: cmake ../ -G "Visual Studio 14 2015 Win64"
 
 test_script:
   - ps: cp .\gsd\Release\*.pyd gsd\
   - ps: cd ..
-  - cmd: C:\Miniconda35-x64\Scripts\nosetests --with-xunit
+  - cmd: pytest --junit-xml=test.xml

--- a/gsd/fl.pyx
+++ b/gsd/fl.pyx
@@ -160,7 +160,7 @@ def open(name, mode, application, schema, schema_version):
             data
     """
 
-    return GSDFile(name, mode, application, schema, schema_version);
+    return GSDFile(str(name), mode, application, schema, schema_version);
 
 cdef class GSDFile:
     """ GSDFile(name, mode, application, schema, schema_version)
@@ -240,6 +240,7 @@ cdef class GSDFile:
         cdef char * c_application;
         cdef char * c_schema;
         cdef int _c_schema_version;
+        cdef str schema_truncated;
 
         if overwrite:
             # create a new file or overwrite an existing one
@@ -290,8 +291,11 @@ cdef class GSDFile:
 
         # validate schema
         if new_api:
-            if self.schema != schema:
-                raise RuntimeError('file ' + name + ' has incorrect schema: ' + schema);
+            schema_truncated = schema
+            if len(schema_truncated) > 64:
+                schema_truncated = schema_truncated[0:63]
+            if self.schema != schema_truncated:
+                raise RuntimeError('file ' + name + ' has incorrect schema: ' + self.schema);
 
         self.__is_open = True;
 
@@ -772,7 +776,7 @@ def create(name, application, schema, schema_version):
     """
 
     _c_schema_version = libgsd.gsd_make_version(schema_version[0], schema_version[1])
-    retval = libgsd.gsd_create(name.encode('utf-8'), application.encode('utf-8'), schema.encode('utf-8'), _c_schema_version);
+    retval = libgsd.gsd_create(str(name).encode('utf-8'), application.encode('utf-8'), schema.encode('utf-8'), _c_schema_version);
 
     if retval == -1:
         raise IOError(*__format_errno(name));

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -784,7 +784,7 @@ def create(name, snapshot=None):
 
     logger.info('creating hoomd gsd file: ' + name);
 
-    gsd.fl.create(name=name, application='gsd.hoomd ' + gsd.__version__, schema='hoomd', schema_version=[1,3]);
+    gsd.fl.create(name=str(name), application='gsd.hoomd ' + gsd.__version__, schema='hoomd', schema_version=[1,3]);
     with gsd.fl.GSDFile(name, 'wb') as f:
         traj = HOOMDTrajectory(f);
         if snapshot is not None:
@@ -844,7 +844,7 @@ def open(name, mode='rb'):
     if gsd is None:
         raise RuntimeError("gsd module is not available");
 
-    gsdfileobj = fl.open(name=name,
+    gsdfileobj = fl.open(name=str(name),
                          mode=mode,
                          application='gsd.hoomd ' + gsd.__version__,
                          schema='hoomd',

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,10 +3,6 @@ current_version = 1.8.1
 commit = False
 tag = False
 
-[nosetests]
-verbosity = 3
-where = tests
-
 [metadata]
 description-file = README.md
 

--- a/tests/test_fl.py
+++ b/tests/test_fl.py
@@ -3,344 +3,319 @@
 
 import gsd.fl
 import gsd.pygsd
-import tempfile
 import numpy
 import platform
-from nose.tools import ok_, eq_, assert_raises
+import pytest
 
-def test_create():
-    with tempfile.TemporaryDirectory() as d:
-        gsd.fl.create(name=d+"/test_create.gsd", application="test_create", schema="none", schema_version=[1,2]);
+def test_create(tmp_path):
+    gsd.fl.create(name=tmp_path / "test_create.gsd", application="test_create", schema="none", schema_version=[1,2]);
 
-def test_dtypes():
-    for typ in [numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64, numpy.int8, numpy.int16, numpy.int32,
-                numpy.int64, numpy.float32, numpy.float64]:
-        yield check_dtype, typ
-
-def check_dtype(typ):
+@pytest.mark.parametrize('typ', [numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64, numpy.int8, numpy.int16,
+                                 numpy.int32, numpy.int64, numpy.float32, numpy.float64])
+def test_dtype(tmp_path, typ):
     data1d = numpy.array([1,2,3,4,5,10012], dtype=typ);
     data2d = numpy.array([[10,20],[30,40],[50,80]], dtype=typ);
 
-    with tempfile.TemporaryDirectory() as d:
-        gsd.fl.create(name=d+"/test_dtype.gsd", application="test_dtype", schema="none", schema_version=[1,2]);
+    gsd.fl.create(name=tmp_path / "test_dtype.gsd", application="test_dtype", schema="none", schema_version=[1,2]);
 
-        with gsd.fl.GSDFile(name=d+"/test_dtype.gsd", mode='wb') as f:
-            f.write_chunk(name='data1d', data=data1d);
-            f.write_chunk(name='data2d', data=data2d);
-            f.end_frame();
+    with gsd.fl.open(name=tmp_path / "test_dtype.gsd", mode='wb', application="test_dtype", schema="none", schema_version=[1,2]) as f:
+        f.write_chunk(name='data1d', data=data1d);
+        f.write_chunk(name='data2d', data=data2d);
+        f.end_frame();
 
-        with gsd.fl.GSDFile(name=d+"/test_dtype.gsd", mode='rb') as f:
-            read_data1d = f.read_chunk(frame=0, name='data1d');
-            read_data2d = f.read_chunk(frame=0, name='data2d');
+    with gsd.fl.open(name=tmp_path / "test_dtype.gsd", mode='rb', application="test_dtype", schema="none", schema_version=[1,2]) as f:
+        read_data1d = f.read_chunk(frame=0, name='data1d');
+        read_data2d = f.read_chunk(frame=0, name='data2d');
 
-            eq_(data1d.dtype, read_data1d.dtype);
-            numpy.testing.assert_array_equal(data1d, read_data1d);
-            eq_(data2d.dtype, read_data2d.dtype);
-            numpy.testing.assert_array_equal(data2d, read_data2d);
+        assert data1d.dtype == read_data1d.dtype;
+        numpy.testing.assert_array_equal(data1d, read_data1d);
+        assert data2d.dtype == read_data2d.dtype;
+        numpy.testing.assert_array_equal(data2d, read_data2d);
 
-        # test again with pygsd
-        with gsd.pygsd.GSDFile(file=open(d+"/test_dtype.gsd", mode='rb')) as f:
-            read_data1d = f.read_chunk(frame=0, name='data1d');
-            read_data2d = f.read_chunk(frame=0, name='data2d');
+    # test again with pygsd
+    with gsd.pygsd.GSDFile(file=open(str(tmp_path / "test_dtype.gsd"), mode='rb')) as f:
+        read_data1d = f.read_chunk(frame=0, name='data1d');
+        read_data2d = f.read_chunk(frame=0, name='data2d');
 
-            eq_(data1d.dtype, read_data1d.dtype);
-            numpy.testing.assert_array_equal(data1d, read_data1d);
-            eq_(data2d.dtype, read_data2d.dtype);
-            numpy.testing.assert_array_equal(data2d, read_data2d);
+        assert data1d.dtype == read_data1d.dtype;
+        numpy.testing.assert_array_equal(data1d, read_data1d);
+        assert data2d.dtype == read_data2d.dtype;
+        numpy.testing.assert_array_equal(data2d, read_data2d);
 
-def test_metadata():
-    with tempfile.TemporaryDirectory() as d:
-        gsd.fl.create(name=d+'/test_metadata.gsd', application='test_metadata', schema='none', schema_version=[1,2]);
+def test_metadata(tmp_path):
+    data = numpy.array([1,2,3,4,5,10012], dtype=numpy.int64);
 
-        data = numpy.array([1,2,3,4,5,10012], dtype=numpy.int64);
-
-        with gsd.fl.GSDFile(name=d+'/test_metadata.gsd', mode='wb') as f:
-            eq_(f.mode, 'wb');
-            for i in range(150):
-                f.write_chunk(name='data', data=data);
-                f.end_frame();
-
-        with gsd.fl.GSDFile(name=d+'/test_metadata.gsd', mode='rb') as f:
-            eq_(f.name, d+'/test_metadata.gsd');
-            eq_(f.mode, 'rb');
-            eq_(f.application, 'test_metadata');
-            eq_(f.schema, 'none');
-            eq_(f.schema_version, (1,2));
-            eq_(f.nframes, 150);
-            ok_(f.gsd_version == (1,0));
-
-        # test again with pygsd
-        with gsd.pygsd.GSDFile(file=open(d+'/test_metadata.gsd', mode='rb')) as f:
-            eq_(f.name, d+'/test_metadata.gsd');
-            eq_(f.mode, 'rb');
-            eq_(f.application, 'test_metadata');
-            eq_(f.schema, 'none');
-            eq_(f.schema_version, (1,2));
-            eq_(f.nframes, 150);
-            ok_(f.gsd_version == (1,0));
-
-def test_append():
-    with tempfile.TemporaryDirectory() as d:
-        gsd.fl.create(name=d+'/test_append.gsd', application='test_append', schema='none', schema_version=[1,2]);
-
-        data = numpy.array([10], dtype=numpy.int64);
-        nframes = 257;
-
-        with gsd.fl.GSDFile(name=d+'/test_append.gsd', mode='ab') as f:
-            eq_(f.mode, 'ab');
-            for i in range(nframes):
-                data[0] = i;
-                f.write_chunk(name='data1', data=data);
-                data[0] = i*10
-                f.write_chunk(name='data10', data=data);
-                f.end_frame();
-
-        with gsd.fl.GSDFile(name=d+'/test_append.gsd', mode='rb') as f:
-            eq_(f.nframes, nframes);
-            for i in range(nframes):
-                data1 = f.read_chunk(frame=i, name='data1');
-                data10 = f.read_chunk(frame=i, name='data10');
-                eq_(data1[0], i);
-                eq_(data10[0], i*10);
-
-        # test again with pygsd
-        with gsd.pygsd.GSDFile(file=open(d+'/test_append.gsd', mode='rb')) as f:
-            eq_(f.nframes, nframes);
-            for i in range(nframes):
-                data1 = f.read_chunk(frame=i, name='data1');
-                data10 = f.read_chunk(frame=i, name='data10');
-                eq_(data1[0], i);
-                eq_(data10[0], i*10);
-
-def test_chunk_exists():
-    with tempfile.TemporaryDirectory() as d:
-        gsd.fl.create(name=d+'/test_chunk_exists.gsd', application='test_chunk_exists', schema='none', schema_version=[1,2]);
-
-        data = numpy.array([1,2,3,4,5,10012], dtype=numpy.int64);
-        with gsd.fl.GSDFile(name=d+'/test_chunk_exists.gsd', mode='wb') as f:
-            f.write_chunk(name='chunk1', data=data);
-            f.end_frame();
-            f.write_chunk(name='abcdefg', data=data);
-            f.end_frame();
-            f.write_chunk(name='test', data=data);
-            f.end_frame();
-
-        with gsd.fl.GSDFile(name=d+'/test_chunk_exists.gsd', mode='rb') as f:
-            ok_(f.chunk_exists(frame=0, name='chunk1'));
-            read_data = f.read_chunk(frame=0, name='chunk1');
-            ok_(f.chunk_exists(frame=1, name='abcdefg'));
-            read_data = f.read_chunk(frame=1, name='abcdefg');
-            ok_(f.chunk_exists(frame=2, name='test'));
-            read_data = f.read_chunk(frame=2, name='test');
-
-            ok_(not f.chunk_exists(frame=1, name='chunk1'));
-            with assert_raises(Exception) as cm:
-                read_data = f.read_chunk(frame=1, name='chunk1');
-            ok_(not f.chunk_exists(frame=2, name='abcdefg'));
-            with assert_raises(Exception) as cm:
-                read_data = f.read_chunk(frame=2, name='abcdefg');
-            ok_(not f.chunk_exists(frame=0, name='test'));
-            with assert_raises(Exception) as cm:
-                read_data = f.read_chunk(frame=0, name='test');
-
-            ok_(not f.chunk_exists(frame=2, name='chunk1'));
-            with assert_raises(Exception) as cm:
-                read_data = f.read_chunk(frame=2, name='chunk1');
-            ok_(not f.chunk_exists(frame=0, name='abcdefg'));
-            with assert_raises(Exception) as cm:
-                read_data = f.read_chunk(frame=0, name='abcdefg');
-            ok_(not f.chunk_exists(frame=1, name='test'));
-            with assert_raises(Exception) as cm:
-                read_data = f.read_chunk(frame=1, name='test');
-
-        # test again with pygsd
-        with gsd.pygsd.GSDFile(file=open(d+'/test_chunk_exists.gsd', mode='rb')) as f:
-            ok_(f.chunk_exists(frame=0, name='chunk1'));
-            read_data = f.read_chunk(frame=0, name='chunk1');
-            ok_(f.chunk_exists(frame=1, name='abcdefg'));
-            read_data = f.read_chunk(frame=1, name='abcdefg');
-            ok_(f.chunk_exists(frame=2, name='test'));
-            read_data = f.read_chunk(frame=2, name='test');
-
-            ok_(not f.chunk_exists(frame=1, name='chunk1'));
-            with assert_raises(Exception) as cm:
-                read_data = f.read_chunk(frame=1, name='chunk1');
-            ok_(not f.chunk_exists(frame=2, name='abcdefg'));
-            with assert_raises(Exception) as cm:
-                read_data = f.read_chunk(frame=2, name='abcdefg');
-            ok_(not f.chunk_exists(frame=0, name='test'));
-            with assert_raises(Exception) as cm:
-                read_data = f.read_chunk(frame=0, name='test');
-
-            ok_(not f.chunk_exists(frame=2, name='chunk1'));
-            with assert_raises(Exception) as cm:
-                read_data = f.read_chunk(frame=2, name='chunk1');
-            ok_(not f.chunk_exists(frame=0, name='abcdefg'));
-            with assert_raises(Exception) as cm:
-                read_data = f.read_chunk(frame=0, name='abcdefg');
-            ok_(not f.chunk_exists(frame=1, name='test'));
-            with assert_raises(Exception) as cm:
-                read_data = f.read_chunk(frame=1, name='test');
-
-def test_readonly_errors():
-    with tempfile.TemporaryDirectory() as d:
-        gsd.fl.create(name=d+'/test_readonly_errors.gsd', application='test_readonly_errors', schema='none', schema_version=[1,2]);
-
-        data = numpy.array([1,2,3,4,5,10012], dtype=numpy.int64);
-        with gsd.fl.GSDFile(name=d+'/test_readonly_errors.gsd', mode='wb') as f:
-            for i in range(10):
-                f.write_chunk(name='chunk1', data=data);
-                f.end_frame();
-
-        data = numpy.array([1,2,3,4,5,10012], dtype=numpy.int64);
-        with gsd.fl.GSDFile(name=d+'/test_readonly_errors.gsd', mode='rb') as f:
-            with assert_raises(Exception) as cm:
-                f.end_frame();
-
-            with assert_raises(Exception) as cm:
-                f.write_chunk(name='chunk1', data=data);
-
-        # test again with pygsd
-        with gsd.pygsd.GSDFile(file=open(d+'/test_readonly_errors.gsd', mode='rb')) as f:
-            with assert_raises(Exception) as cm:
-                f.end_frame();
-
-            with assert_raises(Exception) as cm:
-                f.write_chunk(name='chunk1', data=data);
-
-
-def test_fileio_errors():
-    # These test cause python to crash on windows....
-    if platform.system() != "Windows":
-        with assert_raises(Exception) as cm:
-            gsd.fl.create(name='/this/file/does/not/exist', application='test_readonly_errors', schema='none', schema_version=[1,2]);
-
-        with tempfile.TemporaryDirectory() as d:
-            with open(d+'/test_fileio_errors.gsd', 'wb') as f:
-                f.write(b'test');
-
-            with assert_raises(RuntimeError) as cm:
-                f = gsd.fl.GSDFile(name=d+'/test_fileio_errors.gsd', mode='rb');
-
-def test_dtype_errors():
-    with tempfile.TemporaryDirectory() as d:
-        gsd.fl.create(name=d+'/test_dtype_errors.gsd', application='test_dtype_errors', schema='none', schema_version=[1,2]);
-
-        with assert_raises(Exception) as cm:
-            data = numpy.array([1,2,3,4,5,10012], dtype=numpy.bool_);
-
-            with gsd.fl.GSDFile(name=d+'/test_dtype_errors.gsd', mode='wb') as f:
-                f.write_chunk(name='chunk1', data=data);
-                f.end_frame();
-
-        with assert_raises(Exception) as cm:
-            data = numpy.array([1,2,3,4,5,10012], dtype=numpy.float16);
-
-            with gsd.fl.GSDFile(name=d+'/test_dtype_errors.gsd', mode='wb') as f:
-                f.write_chunk(name='chunk1', data=data);
-                f.end_frame();
-
-        with assert_raises(Exception) as cm:
-            data = numpy.array([1,2,3,4,5,10012], dtype=numpy.complex64);
-
-            with gsd.fl.GSDFile(name=d+'/test_dtype_errors.gsd', mode='wb') as f:
-                f.write_chunk(name='chunk1', data=data);
-                f.end_frame();
-
-        with assert_raises(Exception) as cm:
-            data = numpy.array([1,2,3,4,5,10012], dtype=numpy.complex128);
-
-            with gsd.fl.GSDFile(name=d+'/test_dtype_errors.gsd', mode='wb') as f:
-                f.write_chunk(name='chunk1', data=data);
-                f.end_frame();
-
-def test_truncate():
-    with tempfile.TemporaryDirectory() as d:
-        gsd.fl.create(name=d+'/test_truncate.gsd', application='test_truncate', schema='none', schema_version=[1,2]);
-
-        data = numpy.ascontiguousarray(numpy.random.random(size=(1000,3)), dtype=numpy.float32);
-        with gsd.fl.GSDFile(name=d+'/test_truncate.gsd', mode='wb') as f:
-            eq_(f.mode, 'wb');
-            for i in range(10):
-                f.write_chunk(name='data', data=data);
-                f.end_frame();
-
-            eq_(f.nframes, 10);
-
-            f.truncate();
-            eq_(f.nframes, 0);
-            eq_(f.application, 'test_truncate');
-            eq_(f.schema, 'none');
-            eq_(f.schema_version, (1,2));
-
+    with gsd.fl.open(name=tmp_path / 'test_metadata.gsd', mode='wb', application='test_metadata', schema='none', schema_version=[1,2]) as f:
+        assert f.mode == 'wb';
+        for i in range(150):
             f.write_chunk(name='data', data=data);
             f.end_frame();
 
-        with gsd.fl.GSDFile(name=d+'/test_truncate.gsd', mode='rb') as f:
-            eq_(f.name, d+'/test_truncate.gsd');
-            eq_(f.mode, 'rb');
-            eq_(f.application, 'test_truncate');
-            eq_(f.schema, 'none');
-            eq_(f.schema_version, (1,2));
-            eq_(f.nframes, 1);
+    with gsd.fl.open(name=tmp_path / 'test_metadata.gsd', mode='rb', application='test_metadata', schema='none', schema_version=[1,2]) as f:
+        assert f.name == str(tmp_path / 'test_metadata.gsd');
+        assert f.mode == 'rb';
+        assert f.application == 'test_metadata';
+        assert f.schema == 'none';
+        assert f.schema_version == (1,2);
+        assert f.nframes == 150;
+        assert f.gsd_version == (1,0);
 
-def test_namelen():
-    with tempfile.TemporaryDirectory() as d:
-        app_long = 'abcdefga'*100;
-        schema_long = 'ijklmnop'*100;
-        chunk_long = '12345678'*100;
-        gsd.fl.create(name=d+'/test_namelen.gsd', application=app_long, schema=schema_long, schema_version=[1,2]);
+    # test again with pygsd
+    with gsd.pygsd.GSDFile(file=open(str(tmp_path / 'test_metadata.gsd'), mode='rb')) as f:
+        assert f.name == str(tmp_path / 'test_metadata.gsd');
+        assert f.mode == 'rb';
+        assert f.application == 'test_metadata';
+        assert f.schema == 'none';
+        assert f.schema_version == (1,2);
+        assert f.nframes == 150;
+        assert f.gsd_version == (1,0);
 
-        with gsd.fl.GSDFile(name=d+'/test_namelen.gsd', mode='wb') as f:
-            eq_(f.application, app_long[0:63])
-            eq_(f.schema, schema_long[0:63])
+def test_append(tmp_path):
+    with gsd.fl.open(name=tmp_path / 'test_append.gsd', mode='wb', application='test_append', schema='none', schema_version=[1,2]):
+        pass
 
-            data = numpy.array([1,2,3,4,5,10012], dtype=numpy.int64);
-            f.write_chunk(name=chunk_long, data=data);
+    data = numpy.array([10], dtype=numpy.int64);
+    nframes = 257;
+
+    with gsd.fl.open(name=tmp_path / 'test_append.gsd', mode='ab', application='test_append', schema='none', schema_version=[1,2]) as f:
+        assert f.mode == 'ab';
+        for i in range(nframes):
+            data[0] = i;
+            f.write_chunk(name='data1', data=data);
+            data[0] = i*10
+            f.write_chunk(name='data10', data=data);
             f.end_frame();
 
-        with gsd.fl.GSDFile(name=d+'/test_namelen.gsd', mode='rb') as f:
-            data_read = f.read_chunk(0, name=chunk_long[0:63]);
-            numpy.testing.assert_array_equal(data, data_read);
+    with gsd.fl.open(name=tmp_path / 'test_append.gsd', mode='rb', application='test_append', schema='none', schema_version=[1,2]) as f:
+        assert f.nframes == nframes;
+        for i in range(nframes):
+            data1 = f.read_chunk(frame=i, name='data1');
+            data10 = f.read_chunk(frame=i, name='data10');
+            assert data1[0] == i;
+            assert data10[0] == i*10;
 
-        # test again with pygsd
-        with gsd.pygsd.GSDFile(file=open(d+'/test_namelen.gsd', mode='rb')) as f:
-            data_read = f.read_chunk(0, name=chunk_long[0:63]);
-            numpy.testing.assert_array_equal(data, data_read);
+    # test again with pygsd
+    with gsd.pygsd.GSDFile(file=open(str(tmp_path / 'test_append.gsd'), mode='rb')) as f:
+        assert f.nframes == nframes;
+        for i in range(nframes):
+            data1 = f.read_chunk(frame=i, name='data1');
+            data10 = f.read_chunk(frame=i, name='data10');
+            assert data1[0] == i;
+            assert data10[0] == i*10;
 
-def test_open():
-    with tempfile.TemporaryDirectory() as d:
+def test_chunk_exists(tmp_path):
+    data = numpy.array([1,2,3,4,5,10012], dtype=numpy.int64);
+    with gsd.fl.open(name=tmp_path / 'test_chunk_exists.gsd', mode='wb', application='test_chunk_exists', schema='none', schema_version=[1,2]) as f:
+        f.write_chunk(name='chunk1', data=data);
+        f.end_frame();
+        f.write_chunk(name='abcdefg', data=data);
+        f.end_frame();
+        f.write_chunk(name='test', data=data);
+        f.end_frame();
+
+    with gsd.fl.open(name=tmp_path / 'test_chunk_exists.gsd', mode='rb', application='test_chunk_exists', schema='none', schema_version=[1,2]) as f:
+        assert f.chunk_exists(frame=0, name='chunk1');
+        read_data = f.read_chunk(frame=0, name='chunk1');
+        assert f.chunk_exists(frame=1, name='abcdefg');
+        read_data = f.read_chunk(frame=1, name='abcdefg');
+        assert f.chunk_exists(frame=2, name='test');
+        read_data = f.read_chunk(frame=2, name='test');
+
+        assert not f.chunk_exists(frame=1, name='chunk1');
+        with pytest.raises(Exception) as cm:
+            read_data = f.read_chunk(frame=1, name='chunk1');
+        assert not f.chunk_exists(frame=2, name='abcdefg');
+        with pytest.raises(Exception) as cm:
+            read_data = f.read_chunk(frame=2, name='abcdefg');
+        assert not f.chunk_exists(frame=0, name='test');
+        with pytest.raises(Exception) as cm:
+            read_data = f.read_chunk(frame=0, name='test');
+
+        assert not f.chunk_exists(frame=2, name='chunk1');
+        with pytest.raises(Exception) as cm:
+            read_data = f.read_chunk(frame=2, name='chunk1');
+        assert not f.chunk_exists(frame=0, name='abcdefg');
+        with pytest.raises(Exception) as cm:
+            read_data = f.read_chunk(frame=0, name='abcdefg');
+        assert not f.chunk_exists(frame=1, name='test');
+        with pytest.raises(Exception) as cm:
+            read_data = f.read_chunk(frame=1, name='test');
+
+    # test again with pygsd
+    with gsd.pygsd.GSDFile(file=open(str(tmp_path / 'test_chunk_exists.gsd'), mode='rb')) as f:
+        assert f.chunk_exists(frame=0, name='chunk1');
+        read_data = f.read_chunk(frame=0, name='chunk1');
+        assert f.chunk_exists(frame=1, name='abcdefg');
+        read_data = f.read_chunk(frame=1, name='abcdefg');
+        assert f.chunk_exists(frame=2, name='test');
+        read_data = f.read_chunk(frame=2, name='test');
+
+        assert not f.chunk_exists(frame=1, name='chunk1');
+        with pytest.raises(Exception) as cm:
+            read_data = f.read_chunk(frame=1, name='chunk1');
+        assert not f.chunk_exists(frame=2, name='abcdefg');
+        with pytest.raises(Exception) as cm:
+            read_data = f.read_chunk(frame=2, name='abcdefg');
+        assert not f.chunk_exists(frame=0, name='test');
+        with pytest.raises(Exception) as cm:
+            read_data = f.read_chunk(frame=0, name='test');
+
+        assert not f.chunk_exists(frame=2, name='chunk1');
+        with pytest.raises(Exception) as cm:
+            read_data = f.read_chunk(frame=2, name='chunk1');
+        assert not f.chunk_exists(frame=0, name='abcdefg');
+        with pytest.raises(Exception) as cm:
+            read_data = f.read_chunk(frame=0, name='abcdefg');
+        assert not f.chunk_exists(frame=1, name='test');
+        with pytest.raises(Exception) as cm:
+            read_data = f.read_chunk(frame=1, name='test');
+
+def test_readonly_errors(tmp_path):
+    data = numpy.array([1,2,3,4,5,10012], dtype=numpy.int64);
+    with gsd.fl.open(name=tmp_path / 'test_readonly_errors.gsd', mode='wb', application='test_readonly_errors', schema='none', schema_version=[1,2]) as f:
+        for i in range(10):
+            f.write_chunk(name='chunk1', data=data);
+            f.end_frame();
+
+    data = numpy.array([1,2,3,4,5,10012], dtype=numpy.int64);
+    with gsd.fl.open(name=tmp_path / 'test_readonly_errors.gsd', mode='rb', application='test_readonly_errors', schema='none', schema_version=[1,2]) as f:
+        with pytest.raises(Exception) as cm:
+            f.end_frame();
+
+        with pytest.raises(Exception) as cm:
+            f.write_chunk(name='chunk1', data=data);
+
+    # test again with pygsd
+    with gsd.pygsd.GSDFile(file=open(str(tmp_path / 'test_readonly_errors.gsd'), mode='rb')) as f:
+        with pytest.raises(Exception) as cm:
+            f.end_frame();
+
+        with pytest.raises(Exception) as cm:
+            f.write_chunk(name='chunk1', data=data);
+
+
+def test_fileio_errors(tmp_path):
+    # These test cause python to crash on windows....
+    if platform.system() != "Windows":
+        with pytest.raises(Exception) as cm:
+            gsd.fl.open(name='/this/file/does/not/exist', application='test_readonly_errors', schema='none', schema_version=[1,2]);
+
+        with open(str(tmp_path / 'test_fileio_errors.gsd'), 'wb') as f:
+            f.write(b'test');
+
+        with pytest.raises(RuntimeError) as cm:
+            f = gsd.fl.open(name=tmp_path / 'test_fileio_errors.gsd', mode='rb', application='test_readonly_errors', schema='none', schema_version=[1,2]);
+
+def test_dtype_errors(tmp_path):
+    with pytest.raises(Exception) as cm:
+        data = numpy.array([1,2,3,4,5,10012], dtype=numpy.bool_);
+
+        with gsd.fl.open(name=tmp_path / 'test_dtype_errors.gsd', mode='wb', application='test_dtype_errors', schema='none', schema_version=[1,2]) as f:
+            f.write_chunk(name='chunk1', data=data);
+            f.end_frame();
+
+    with pytest.raises(Exception) as cm:
+        data = numpy.array([1,2,3,4,5,10012], dtype=numpy.float16);
+
+        with gsd.fl.open(name=tmp_path / 'test_dtype_errors.gsd', mode='wb', application='test_dtype_errors', schema='none', schema_version=[1,2]) as f:
+            f.write_chunk(name='chunk1', data=data);
+            f.end_frame();
+
+    with pytest.raises(Exception) as cm:
+        data = numpy.array([1,2,3,4,5,10012], dtype=numpy.complex64);
+
+        with gsd.fl.open(name=tmp_path / 'test_dtype_errors.gsd', mode='wb', application='test_dtype_errors', schema='none', schema_version=[1,2]) as f:
+            f.write_chunk(name='chunk1', data=data);
+            f.end_frame();
+
+    with pytest.raises(Exception) as cm:
+        data = numpy.array([1,2,3,4,5,10012], dtype=numpy.complex128);
+
+        with gsd.fl.open(name=tmp_path / 'test_dtype_errors.gsd', mode='wb', application='test_dtype_errors', schema='none', schema_version=[1,2]) as f:
+            f.write_chunk(name='chunk1', data=data);
+            f.end_frame();
+
+def test_truncate(tmp_path):
+    data = numpy.ascontiguousarray(numpy.random.random(size=(1000,3)), dtype=numpy.float32);
+    with gsd.fl.open(name=tmp_path / 'test_truncate.gsd', mode='wb', application='test_truncate', schema='none', schema_version=[1,2]) as f:
+        assert f.mode == 'wb';
+        for i in range(10):
+            f.write_chunk(name='data', data=data);
+            f.end_frame();
+
+        assert f.nframes == 10;
+
+        f.truncate();
+        assert f.nframes == 0;
+        assert f.application == 'test_truncate';
+        assert f.schema == 'none';
+        assert f.schema_version == (1,2);
+
+        f.write_chunk(name='data', data=data);
+        f.end_frame();
+
+    with gsd.fl.open(name=tmp_path / 'test_truncate.gsd', mode='rb', application='test_truncate', schema='none', schema_version=[1,2]) as f:
+        assert f.name == str(tmp_path / 'test_truncate.gsd');
+        assert f.mode == 'rb';
+        assert f.application == 'test_truncate';
+        assert f.schema == 'none';
+        assert f.schema_version == (1,2);
+        assert f.nframes == 1;
+
+def test_namelen(tmp_path):
+    app_long = 'abcdefga'*100;
+    schema_long = 'ijklmnop'*100;
+    chunk_long = '12345678'*100;
+
+    with gsd.fl.open(name=tmp_path / 'test_namelen.gsd', mode='wb', application=app_long, schema=schema_long, schema_version=[1,2]) as f:
+        assert f.application == app_long[0:63]
+        assert f.schema == schema_long[0:63]
+
         data = numpy.array([1,2,3,4,5,10012], dtype=numpy.int64);
+        f.write_chunk(name=chunk_long, data=data);
+        f.end_frame();
 
-        with gsd.fl.GSDFile(name=d+'/test.gsd', mode='xb', application='test_open', schema='none', schema_version=[1,2]) as f:
-            f.write_chunk(name='chunk1', data=data);
-            f.end_frame();
+    with gsd.fl.open(name=tmp_path / 'test_namelen.gsd', mode='rb', application=app_long, schema=schema_long, schema_version=[1,2]) as f:
+        data_read = f.read_chunk(0, name=chunk_long[0:63]);
+        numpy.testing.assert_array_equal(data, data_read);
 
-        with gsd.fl.GSDFile(name=d+'/test_2.gsd', mode='xb+', application='test_open', schema='none', schema_version=[1,2]) as f:
-            f.write_chunk(name='chunk1', data=data);
-            f.end_frame();
-            f.read_chunk(0, name='chunk1');
+    # test again with pygsd
+    with gsd.pygsd.GSDFile(file=open(str(tmp_path / 'test_namelen.gsd'), mode='rb')) as f:
+        data_read = f.read_chunk(0, name=chunk_long[0:63]);
+        numpy.testing.assert_array_equal(data, data_read);
 
-        with gsd.fl.GSDFile(name=d+'/test.gsd', mode='wb', application='test_open', schema='none', schema_version=[1,2]) as f:
-            f.write_chunk(name='chunk1', data=data);
-            f.end_frame();
+def test_open(tmp_path):
+    data = numpy.array([1,2,3,4,5,10012], dtype=numpy.int64);
 
-        with gsd.fl.GSDFile(name=d+'/test.gsd', mode='wb+', application='test_open', schema='none', schema_version=[1,2]) as f:
-            f.write_chunk(name='chunk1', data=data);
-            f.end_frame();
-            f.read_chunk(0, name='chunk1');
+    with gsd.fl.open(name=tmp_path / 'test.gsd', mode='xb', application='test_open', schema='none', schema_version=[1,2]) as f:
+        f.write_chunk(name='chunk1', data=data);
+        f.end_frame();
 
-        with gsd.fl.GSDFile(name=d+'/test.gsd', mode='ab', application='test_open', schema='none', schema_version=[1,2]) as f:
-            f.write_chunk(name='chunk1', data=data);
-            f.end_frame();
+    with gsd.fl.open(name=tmp_path / 'test_2.gsd', mode='xb+', application='test_open', schema='none', schema_version=[1,2]) as f:
+        f.write_chunk(name='chunk1', data=data);
+        f.end_frame();
+        f.read_chunk(0, name='chunk1');
 
-        with gsd.fl.GSDFile(name=d+'/test.gsd', mode='rb', application='test_open', schema='none', schema_version=[1,2]) as f:
-            f.read_chunk(0, name='chunk1');
-            f.read_chunk(1, name='chunk1');
+    with gsd.fl.open(name=tmp_path / 'test.gsd', mode='wb', application='test_open', schema='none', schema_version=[1,2]) as f:
+        f.write_chunk(name='chunk1', data=data);
+        f.end_frame();
 
-        with gsd.fl.GSDFile(name=d+'/test.gsd', mode='rb+', application='test_open', schema='none', schema_version=[1,2]) as f:
-            f.write_chunk(name='chunk1', data=data);
-            f.end_frame();
-            f.read_chunk(0, name='chunk1');
-            f.read_chunk(1, name='chunk1');
-            f.read_chunk(2, name='chunk1');
+    with gsd.fl.open(name=tmp_path / 'test.gsd', mode='wb+', application='test_open', schema='none', schema_version=[1,2]) as f:
+        f.write_chunk(name='chunk1', data=data);
+        f.end_frame();
+        f.read_chunk(0, name='chunk1');
+
+    with gsd.fl.open(name=tmp_path / 'test.gsd', mode='ab', application='test_open', schema='none', schema_version=[1,2]) as f:
+        f.write_chunk(name='chunk1', data=data);
+        f.end_frame();
+
+    with gsd.fl.open(name=tmp_path / 'test.gsd', mode='rb', application='test_open', schema='none', schema_version=[1,2]) as f:
+        f.read_chunk(0, name='chunk1');
+        f.read_chunk(1, name='chunk1');
+
+    with gsd.fl.open(name=tmp_path / 'test.gsd', mode='rb+', application='test_open', schema='none', schema_version=[1,2]) as f:
+        f.write_chunk(name='chunk1', data=data);
+        f.end_frame();
+        f.read_chunk(0, name='chunk1');
+        f.read_chunk(1, name='chunk1');
+        f.read_chunk(2, name='chunk1');

--- a/tests/test_hoomd.py
+++ b/tests/test_hoomd.py
@@ -3,534 +3,496 @@
 
 import gsd.fl
 import gsd.hoomd
-import tempfile
 import numpy
-from nose.tools import ok_, eq_, assert_raises
+import pytest
 
-def test_create():
-    with tempfile.TemporaryDirectory() as d:
-        gsd.hoomd.create(name=d+"/test_create.gsd", snapshot=None);
+def test_create(tmp_path):
+    with gsd.hoomd.open(name=tmp_path / "test_create.gsd", mode='wb') as hf:
+        assert hf.file.schema == 'hoomd';
+        assert hf.file.schema_version >= (1,0);
 
-        with gsd.fl.GSDFile(name=d+"/test_create.gsd", mode='rb') as f:
-            hf = gsd.hoomd.HOOMDTrajectory(f);
-            eq_(f.schema, 'hoomd');
-            ok_(f.schema_version >= (1,0));
+def test_append(tmp_path):
+    snap = gsd.hoomd.Snapshot();
+    snap.particles.N = 10;
 
-def test_append():
-    with tempfile.TemporaryDirectory() as d:
-        snap = gsd.hoomd.Snapshot();
-        snap.particles.N = 10;
-        gsd.hoomd.create(name=d+"/test_append.gsd", snapshot=snap);
+    with gsd.hoomd.open(name=tmp_path / "test_append.gsd", mode='wb') as hf:
+        for i in range(5):
+            snap.configuration.step=i+1;
+            hf.append(snap);
 
-        with gsd.fl.GSDFile(name=d+"/test_append.gsd", mode='wb') as f:
-            hf = gsd.hoomd.HOOMDTrajectory(f);
-            for i in range(5):
-                snap.configuration.step=i+1;
-                hf.append(snap);
-
-        with gsd.fl.GSDFile(name=d+"/test_append.gsd", mode='rb') as f:
-            hf = gsd.hoomd.HOOMDTrajectory(f);
-            eq_(len(hf), 6);
+    with gsd.hoomd.open(name=tmp_path / "test_append.gsd", mode='rb') as hf:
+        assert len(hf) == 5;
 
 def create_frame(i):
     snap = gsd.hoomd.Snapshot();
     snap.configuration.step = i+1;
     return snap
 
-def test_extend():
-    with tempfile.TemporaryDirectory() as d:
-        snap = gsd.hoomd.Snapshot();
-        snap.particles.N = 10;
-        gsd.hoomd.create(name=d+"/test_extend.gsd", snapshot=snap);
-
-        with gsd.fl.GSDFile(name=d+"/test_extend.gsd", mode='wb') as f:
-            hf = gsd.hoomd.HOOMDTrajectory(f);
-            hf.extend((create_frame(i) for i in range(5)));
-
-        with gsd.fl.GSDFile(name=d+"/test_extend.gsd", mode='rb') as f:
-            hf = gsd.hoomd.HOOMDTrajectory(f);
-            eq_(len(hf), 6);
-
-def test_defaults():
-    with tempfile.TemporaryDirectory() as d:
-        snap = gsd.hoomd.Snapshot();
-        snap.particles.N = 2;
-        snap.bonds.N = 3;
-        snap.angles.N = 4;
-        snap.dihedrals.N = 5;
-        snap.impropers.N = 6;
-        snap.constraints.N = 4;
-        snap.pairs.N = 7;
-        gsd.hoomd.create(name=d+"/test_defaults.gsd", snapshot=snap);
-
-        with gsd.fl.GSDFile(name=d+"/test_defaults.gsd", mode='rb') as f:
-            hf = gsd.hoomd.HOOMDTrajectory(f);
-            s = hf.read_frame(0);
-
-            eq_(s.configuration.step, 0);
-            eq_(s.configuration.dimensions, 3);
-            numpy.testing.assert_array_equal(s.configuration.box, numpy.array([1,1,1,0,0,0], dtype=numpy.float32));
-            eq_(s.particles.N, 2);
-            eq_(s.particles.types, ['A']);
-            numpy.testing.assert_array_equal(s.particles.typeid, numpy.array([0,0], dtype=numpy.uint32));
-            numpy.testing.assert_array_equal(s.particles.mass, numpy.array([1,1], dtype=numpy.float32));
-            numpy.testing.assert_array_equal(s.particles.diameter, numpy.array([1,1], dtype=numpy.float32));
-            numpy.testing.assert_array_equal(s.particles.body, numpy.array([-1,-1], dtype=numpy.int32));
-            numpy.testing.assert_array_equal(s.particles.charge, numpy.array([0,0], dtype=numpy.float32));
-            numpy.testing.assert_array_equal(s.particles.moment_inertia, numpy.array([[0,0,0],[0,0,0]], dtype=numpy.float32));
-            numpy.testing.assert_array_equal(s.particles.position, numpy.array([[0,0,0],[0,0,0]], dtype=numpy.float32));
-            numpy.testing.assert_array_equal(s.particles.orientation, numpy.array([[1,0,0,0],[1,0,0,0]], dtype=numpy.float32));
-            numpy.testing.assert_array_equal(s.particles.velocity, numpy.array([[0,0,0],[0,0,0]], dtype=numpy.float32));
-            numpy.testing.assert_array_equal(s.particles.angmom, numpy.array([[0,0,0,0],[0,0,0,0]], dtype=numpy.float32));
-            numpy.testing.assert_array_equal(s.particles.image, numpy.array([[0,0,0],[0,0,0]], dtype=numpy.int32));
-
-            eq_(s.bonds.N, 3);
-            eq_(s.bonds.types, []);
-            numpy.testing.assert_array_equal(s.bonds.typeid, numpy.array([0,0,0], dtype=numpy.uint32));
-            numpy.testing.assert_array_equal(s.bonds.group, numpy.array([[0,0],[0,0],[0,0]], dtype=numpy.uint32));
-
-            eq_(s.angles.N, 4);
-            eq_(s.angles.types, []);
-            numpy.testing.assert_array_equal(s.angles.typeid, numpy.array([0,0,0,0], dtype=numpy.uint32));
-            numpy.testing.assert_array_equal(s.angles.group, numpy.array([[0,0,0],[0,0,0],[0,0,0],[0,0,0]], dtype=numpy.uint32));
-
-            eq_(s.dihedrals.N, 5);
-            eq_(s.dihedrals.types, []);
-            numpy.testing.assert_array_equal(s.dihedrals.typeid, numpy.array([0,0,0,0,0], dtype=numpy.uint32));
-            numpy.testing.assert_array_equal(s.dihedrals.group, numpy.array([[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0]], dtype=numpy.uint32));
-
-            eq_(s.impropers.N, 6);
-            eq_(s.impropers.types, []);
-            numpy.testing.assert_array_equal(s.impropers.typeid, numpy.array([0,0,0,0,0,0], dtype=numpy.uint32));
-            numpy.testing.assert_array_equal(s.impropers.group, numpy.array([[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0]], dtype=numpy.uint32));
-
-            eq_(s.constraints.N, 4);
-            numpy.testing.assert_array_equal(s.constraints.value, numpy.array([0,0,0,0], dtype=numpy.float32));
-            numpy.testing.assert_array_equal(s.constraints.group, numpy.array([[0,0],[0,0],[0,0], [0,0]], dtype=numpy.uint32));
-
-            eq_(s.pairs.N, 7);
-            eq_(s.pairs.types, []);
-            numpy.testing.assert_array_equal(s.pairs.typeid, numpy.array([0]*7, dtype=numpy.uint32));
-            numpy.testing.assert_array_equal(s.pairs.group, numpy.array([[0,0]]*7, dtype=numpy.uint32));
-
-            eq_(len(s.state), 0)
-
-def test_fallback():
-    with tempfile.TemporaryDirectory() as d:
-        snap0 = gsd.hoomd.Snapshot();
-        snap0.configuration.step = 10000;
-        snap0.configuration.dimensions = 2;
-        snap0.configuration.box = [4,5,6,1.0,0.5,0.25];
-        snap0.particles.N = 2;
-        snap0.particles.types = ['A', 'B', 'C']
-        snap0.particles.typeid = [1,2];
-        snap0.particles.mass = [2,3];
-        snap0.particles.diameter = [3,4];
-        snap0.particles.body = [10, 20];
-        snap0.particles.charge = [0.5, 0.25];
-        snap0.particles.moment_inertia = [[1,2,3], [3,2,1]];
-        snap0.particles.position = [[0.1, 0.2, 0.3], [-1.0, -2.0, -3.0]];
-        snap0.particles.orientation = [[1, 0.1, 0.2, 0.3], [0, -1.0, -2.0, -3.0]];
-        snap0.particles.velocity = [[1.1, 2.2, 3.3], [-3.3, -2.2, -1.1]];
-        snap0.particles.angmom = [[1, 1.1, 2.2, 3.3], [-1, -3.3, -2.2, -1.1]];
-        snap0.particles.image = [[10, 20, 30], [5, 6, 7]];
-
-        snap0.bonds.N = 1;
-        snap0.bonds.types = ['bondA', 'bondB']
-        snap0.bonds.typeid = [1];
-        snap0.bonds.group = [[0,1]];
-
-        snap0.angles.N = 1;
-        snap0.angles.typeid = [2];
-        snap0.angles.types = ['angleA', 'angleB']
-        snap0.angles.group = [[0,1, 0]];
-
-        snap0.dihedrals.N = 1;
-        snap0.dihedrals.typeid = [3];
-        snap0.dihedrals.types = ['dihedralA', 'dihedralB']
-        snap0.dihedrals.group = [[0,1, 1, 0]];
-
-        snap0.impropers.N = 1;
-        snap0.impropers.typeid = [4];
-        snap0.impropers.types = ['improperA', 'improperB']
-        snap0.impropers.group = [[1, 0, 0, 1]];
-
-        snap0.constraints.N = 1;
-        snap0.constraints.value = [1.1];
-        snap0.constraints.group = [[0,1]];
-
-        snap0.pairs.N = 1;
-        snap0.pairs.types = ['pairA', 'pairB']
-        snap0.pairs.typeid = [1];
-        snap0.pairs.group = [[0,3]];
-
-        snap1 = gsd.hoomd.Snapshot();
-        snap1.particles.N = 2;
-        snap1.particles.position = [[-2, -1, 0], [1, 3.0, 0.5]];
-
-        snap2 = gsd.hoomd.Snapshot();
-        snap2.particles.N = 3;
-        snap2.particles.types = ['q', 's'];
-        snap2.bonds.N = 3;
-        snap2.angles.N = 4;
-        snap2.dihedrals.N = 5;
-        snap2.impropers.N = 6;
-        snap2.constraints.N = 4;
-        snap2.pairs.N = 7;
-
-        gsd.hoomd.create(name=d+"/test_fallback.gsd");
-
-        with gsd.fl.GSDFile(name=d+"/test_fallback.gsd", mode='wb') as f:
-            hf = gsd.hoomd.HOOMDTrajectory(f);
-            hf.extend([snap0, snap1, snap2]);
-
-        with gsd.fl.GSDFile(name=d+"/test_fallback.gsd", mode='rb') as f:
-            hf = gsd.hoomd.HOOMDTrajectory(f);
-            eq_(len(hf), 3);
-            s = hf.read_frame(0);
-
-            eq_(s.configuration.step, snap0.configuration.step);
-            eq_(s.configuration.dimensions, snap0.configuration.dimensions);
-            numpy.testing.assert_array_equal(s.configuration.box, snap0.configuration.box);
-            eq_(s.particles.N, snap0.particles.N);
-            eq_(s.particles.types, snap0.particles.types);
-            numpy.testing.assert_array_equal(s.particles.typeid, snap0.particles.typeid);
-            numpy.testing.assert_array_equal(s.particles.mass, snap0.particles.mass);
-            numpy.testing.assert_array_equal(s.particles.diameter, snap0.particles.diameter);
-            numpy.testing.assert_array_equal(s.particles.body, snap0.particles.body);
-            numpy.testing.assert_array_equal(s.particles.charge, snap0.particles.charge);
-            numpy.testing.assert_array_equal(s.particles.moment_inertia, snap0.particles.moment_inertia);
-            numpy.testing.assert_array_equal(s.particles.position, snap0.particles.position);
-            numpy.testing.assert_array_equal(s.particles.orientation, snap0.particles.orientation);
-            numpy.testing.assert_array_equal(s.particles.velocity, snap0.particles.velocity);
-            numpy.testing.assert_array_equal(s.particles.angmom, snap0.particles.angmom);
-            numpy.testing.assert_array_equal(s.particles.image, snap0.particles.image);
-
-            eq_(s.bonds.N, snap0.bonds.N);
-            eq_(s.bonds.types, snap0.bonds.types);
-            numpy.testing.assert_array_equal(s.bonds.typeid, snap0.bonds.typeid);
-            numpy.testing.assert_array_equal(s.bonds.group, snap0.bonds.group);
-
-            eq_(s.angles.N, snap0.angles.N);
-            eq_(s.angles.types, snap0.angles.types);
-            numpy.testing.assert_array_equal(s.angles.typeid, snap0.angles.typeid);
-            numpy.testing.assert_array_equal(s.angles.group, snap0.angles.group);
-
-            eq_(s.dihedrals.N, snap0.dihedrals.N);
-            eq_(s.dihedrals.types, snap0.dihedrals.types);
-            numpy.testing.assert_array_equal(s.dihedrals.typeid, snap0.dihedrals.typeid);
-            numpy.testing.assert_array_equal(s.dihedrals.group, snap0.dihedrals.group);
-
-            eq_(s.impropers.N, snap0.impropers.N);
-            eq_(s.impropers.types, snap0.impropers.types);
-            numpy.testing.assert_array_equal(s.impropers.typeid, snap0.impropers.typeid);
-            numpy.testing.assert_array_equal(s.impropers.group, snap0.impropers.group);
-
-            eq_(s.constraints.N, snap0.constraints.N);
-            numpy.testing.assert_array_equal(s.constraints.value, snap0.constraints.value);
-            numpy.testing.assert_array_equal(s.constraints.group, snap0.constraints.group);
-
-            eq_(s.pairs.N, snap0.pairs.N);
-            eq_(s.pairs.types, snap0.pairs.types);
-            numpy.testing.assert_array_equal(s.pairs.typeid, snap0.pairs.typeid);
-            numpy.testing.assert_array_equal(s.pairs.group, snap0.pairs.group);
-
-            # test that everything but position remained the same in frame 1
-            s = hf.read_frame(1);
-
-            eq_(s.configuration.step, snap0.configuration.step);
-            eq_(s.configuration.dimensions, snap0.configuration.dimensions);
-            numpy.testing.assert_array_equal(s.configuration.box, snap0.configuration.box);
-            eq_(s.particles.N, snap0.particles.N);
-            eq_(s.particles.types, snap0.particles.types);
-            numpy.testing.assert_array_equal(s.particles.typeid, snap0.particles.typeid);
-            numpy.testing.assert_array_equal(s.particles.mass, snap0.particles.mass);
-            numpy.testing.assert_array_equal(s.particles.diameter, snap0.particles.diameter);
-            numpy.testing.assert_array_equal(s.particles.body, snap0.particles.body);
-            numpy.testing.assert_array_equal(s.particles.charge, snap0.particles.charge);
-            numpy.testing.assert_array_equal(s.particles.moment_inertia, snap0.particles.moment_inertia);
-            numpy.testing.assert_array_equal(s.particles.position, snap1.particles.position);
-            numpy.testing.assert_array_equal(s.particles.orientation, snap0.particles.orientation);
-            numpy.testing.assert_array_equal(s.particles.velocity, snap0.particles.velocity);
-            numpy.testing.assert_array_equal(s.particles.angmom, snap0.particles.angmom);
-            numpy.testing.assert_array_equal(s.particles.image, snap0.particles.image);
-
-            eq_(s.bonds.N, snap0.bonds.N);
-            eq_(s.bonds.types, snap0.bonds.types);
-            numpy.testing.assert_array_equal(s.bonds.typeid, snap0.bonds.typeid);
-            numpy.testing.assert_array_equal(s.bonds.group, snap0.bonds.group);
-
-            eq_(s.angles.N, snap0.angles.N);
-            eq_(s.angles.types, snap0.angles.types);
-            numpy.testing.assert_array_equal(s.angles.typeid, snap0.angles.typeid);
-            numpy.testing.assert_array_equal(s.angles.group, snap0.angles.group);
-
-            eq_(s.dihedrals.N, snap0.dihedrals.N);
-            eq_(s.dihedrals.types, snap0.dihedrals.types);
-            numpy.testing.assert_array_equal(s.dihedrals.typeid, snap0.dihedrals.typeid);
-            numpy.testing.assert_array_equal(s.dihedrals.group, snap0.dihedrals.group);
-
-            eq_(s.impropers.N, snap0.impropers.N);
-            eq_(s.impropers.types, snap0.impropers.types);
-            numpy.testing.assert_array_equal(s.impropers.typeid, snap0.impropers.typeid);
-            numpy.testing.assert_array_equal(s.impropers.group, snap0.impropers.group);
-
-            eq_(s.constraints.N, snap0.constraints.N);
-            numpy.testing.assert_array_equal(s.constraints.value, snap0.constraints.value);
-            numpy.testing.assert_array_equal(s.constraints.group, snap0.constraints.group);
-
-            eq_(s.pairs.N, snap0.pairs.N);
-            eq_(s.pairs.types, snap0.pairs.types);
-            numpy.testing.assert_array_equal(s.pairs.typeid, snap0.pairs.typeid);
-            numpy.testing.assert_array_equal(s.pairs.group, snap0.pairs.group);
-
-            # check that the third frame goes back to defaults because it has a different N
-            s = hf.read_frame(2);
-
-            eq_(s.particles.N, 3);
-            eq_(s.particles.types, ['q', 's']);
-            numpy.testing.assert_array_equal(s.particles.typeid, numpy.array([0,0,0], dtype=numpy.uint32));
-            numpy.testing.assert_array_equal(s.particles.mass, numpy.array([1,1,1], dtype=numpy.float32));
-            numpy.testing.assert_array_equal(s.particles.diameter, numpy.array([1,1,1], dtype=numpy.float32));
-            numpy.testing.assert_array_equal(s.particles.body, numpy.array([-1,-1,-1], dtype=numpy.float32));
-            numpy.testing.assert_array_equal(s.particles.charge, numpy.array([0,0,0], dtype=numpy.float32));
-            numpy.testing.assert_array_equal(s.particles.moment_inertia, numpy.array([[0,0,0],[0,0,0],[0,0,0]], dtype=numpy.float32));
-            numpy.testing.assert_array_equal(s.particles.position, numpy.array([[0,0,0],[0,0,0],[0,0,0]], dtype=numpy.float32));
-            numpy.testing.assert_array_equal(s.particles.orientation, numpy.array([[1,0,0,0],[1,0,0,0],[1,0,0,0]], dtype=numpy.float32));
-            numpy.testing.assert_array_equal(s.particles.velocity, numpy.array([[0,0,0],[0,0,0],[0,0,0]], dtype=numpy.float32));
-            numpy.testing.assert_array_equal(s.particles.angmom, numpy.array([[0,0,0,0],[0,0,0,0],[0,0,0,0]], dtype=numpy.float32));
-            numpy.testing.assert_array_equal(s.particles.image, numpy.array([[0,0,0],[0,0,0],[0,0,0]], dtype=numpy.int32));
-
-            eq_(s.bonds.N, 3);
-            eq_(s.bonds.types, snap0.bonds.types);
-            numpy.testing.assert_array_equal(s.bonds.typeid, numpy.array([0,0,0], dtype=numpy.uint32));
-            numpy.testing.assert_array_equal(s.bonds.group, numpy.array([[0,0],[0,0],[0,0]], dtype=numpy.uint32));
-
-            eq_(s.angles.N, 4);
-            eq_(s.angles.types, snap0.angles.types);
-            numpy.testing.assert_array_equal(s.angles.typeid, numpy.array([0,0,0,0], dtype=numpy.uint32));
-            numpy.testing.assert_array_equal(s.angles.group, numpy.array([[0,0,0],[0,0,0],[0,0,0],[0,0,0]], dtype=numpy.uint32));
-
-            eq_(s.dihedrals.N, 5);
-            eq_(s.dihedrals.types, snap0.dihedrals.types);
-            numpy.testing.assert_array_equal(s.dihedrals.typeid, numpy.array([0,0,0,0,0], dtype=numpy.uint32));
-            numpy.testing.assert_array_equal(s.dihedrals.group, numpy.array([[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0]], dtype=numpy.uint32));
-
-            eq_(s.impropers.N, 6);
-            eq_(s.impropers.types, snap0.impropers.types);
-            numpy.testing.assert_array_equal(s.impropers.typeid, numpy.array([0,0,0,0,0,0], dtype=numpy.uint32));
-            numpy.testing.assert_array_equal(s.impropers.group, numpy.array([[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0]], dtype=numpy.uint32));
-
-            eq_(s.constraints.N, 4);
-            numpy.testing.assert_array_equal(s.constraints.value, numpy.array([0,0,0,0], dtype=numpy.float32));
-            numpy.testing.assert_array_equal(s.constraints.group, numpy.array([[0,0],[0,0],[0,0], [0,0]], dtype=numpy.uint32));
-
-            eq_(s.pairs.N, 7);
-            eq_(s.pairs.types, snap0.pairs.types);
-            numpy.testing.assert_array_equal(s.pairs.typeid, numpy.array([0]*7, dtype=numpy.uint32));
-            numpy.testing.assert_array_equal(s.pairs.group, numpy.array([[0,0]]*7, dtype=numpy.uint32));
-
-
-def test_fallback2():
-    with tempfile.TemporaryDirectory() as d:
-        snap0 = gsd.hoomd.Snapshot();
-        snap0.configuration.step = 1;
-        snap0.configuration.dimensions = 3;
-        snap0.particles.N = 2;
-        snap0.particles.mass = [2,3];
-
-        snap1 = gsd.hoomd.Snapshot();
-        snap1.configuration.step = 2;
-        snap1.particles.N = 2;
-        snap1.particles.position = [[1,2,3],[4,5,6]];
-
-        gsd.hoomd.create(name=d+"/test_fallback2.gsd");
-
-        with gsd.fl.GSDFile(name=d+"/test_fallback2.gsd", mode='wb') as f:
-            hf = gsd.hoomd.HOOMDTrajectory(f);
-            hf.extend([snap0, snap1]);
-
-        with gsd.fl.GSDFile(name=d+"/test_fallback2.gsd", mode='rb') as f:
-            hf = gsd.hoomd.HOOMDTrajectory(f);
-            eq_(len(hf), 2);
-
-            s = hf.read_frame(1);
-            numpy.testing.assert_array_equal(s.particles.mass, snap0.particles.mass);
-
-def test_iteration():
-    with tempfile.TemporaryDirectory() as d:
-
-        with gsd.hoomd.open(name=d+"/test_iteration.gsd", mode='wb') as hf:
-            hf.extend((create_frame(i) for i in range(20)));
-
-        with gsd.hoomd.open(name=d+"/test_iteration.gsd", mode='rb') as hf:
-            step = hf[-1].configuration.step;
-            eq_(step, 20);
-
-            step = hf[-2].configuration.step;
-            eq_(step, 19);
-
-            step = hf[-3].configuration.step;
-            eq_(step, 18);
-
-            step = hf[0].configuration.step;
-            eq_(step, 1);
-
-            step = hf[-20].configuration.step;
-            eq_(step, 1);
-
-            with assert_raises(IndexError) as cm:
-                step = hf[-21].configuration.step;
-
-            with assert_raises(IndexError) as cm:
-                step = hf[20]
-
-            snaps = hf[5:10];
-            steps = [snap.configuration.step for snap in snaps];
-            eq_(steps, [6,7,8,9,10]);
-
-            snaps = hf[15:50];
-            steps = [snap.configuration.step for snap in snaps];
-            eq_(steps, [16,17,18,19,20]);
-
-            snaps = hf[15:-3];
-            steps = [snap.configuration.step for snap in snaps];
-            eq_(steps, [16,17]);
-
-def test_slicing_and_iteration():
-    with tempfile.TemporaryDirectory() as d:
-
-        with gsd.hoomd.open(name=d+"/test_slicing.gsd", mode='wb') as hf:
-            hf.extend((create_frame(i) for i in range(20)));
-
-        with gsd.hoomd.open(name=d+"/test_slicing.gsd", mode='rb') as hf:
-            # Test len()-function on trajectory and sliced trajectory.
-            eq_(len(hf), 20)
-            eq_(len(hf[:10]), 10)
-
-            # Test len()-function with explicit iterator.
-            eq_(len(iter(hf)), len(hf))
-            eq_(len(iter(hf[:10])), len(hf[:10]))
-
-            # Test iteration with implicit iterator.
-            # All iterations are run twice to check for issues
-            # with iterator exhaustion.
-            eq_(len(list(hf)), len(hf))
-            eq_(len(list(hf)), len(hf))
-            eq_(len(list(hf[:10])), len(hf[:10]))
-            eq_(len(list(hf[:10])), len(hf[:10]))
-
-            # Test iteration with explicit iterator.
-            hf_iter = iter(hf)
-            eq_(len(hf_iter), len(hf))  # sanity check
-            eq_(len(list(hf_iter)), len(hf))
-            eq_(len(list(hf_iter)), len(hf))
-
-            # Test iteration with explicit sliced iterator.
-            hf_iter = iter(hf[:10])
-            eq_(len(hf_iter), 10)  # sanity check
-            eq_(len(list(hf_iter)), 10)
-            eq_(len(list(hf_iter)), 10)
-
-            # Test frame selection
-            with assert_raises(IndexError):
-                hf[len(hf)]
-            eq_(hf[0].configuration.step, hf[0].configuration.step)
-            eq_(hf[len(hf) - 1].configuration.step, hf[-1].configuration.step)
-
-
-def test_view_slicing_and_iteration():
-    with tempfile.TemporaryDirectory() as d:
-
-        with gsd.hoomd.open(name=d+"/test_slicing.gsd", mode='wb') as hf:
-            hf.extend((create_frame(i) for i in range(40)));
-
-        with gsd.hoomd.open(name=d+"/test_slicing.gsd", mode='rb') as hf:
-            view = hf[::2]
-
-            # Test len()-function on trajectory and sliced view.
-            eq_(len(view), 20)
-            eq_(len(view[:10]), 10)
-            eq_(len(view[::2]), 10)
-
-            # Test len()-function with explicit iterator.
-            eq_(len(iter(view)), len(view))
-            eq_(len(iter(view[:10])), len(view[:10]))
-
-            # Test iteration with implicit iterator.
-            # All iterations are run twice to check for issues
-            # with iterator exhaustion.
-            eq_(len(list(view)), len(view))
-            eq_(len(list(view)), len(view))
-            eq_(len(list(view[:10])), len(view[:10]))
-            eq_(len(list(view[:10])), len(view[:10]))
-            eq_(len(list(view[::2])), len(view[::2]))
-            eq_(len(list(view[::2])), len(view[::2]))
-
-            # Test iteration with explicit iterator.
-            view_iter = iter(view)
-            eq_(len(view_iter), len(view))  # sanity check
-            eq_(len(list(view_iter)), len(view))
-            eq_(len(list(view_iter)), len(view))
-
-            # Test iteration with explicit sliced iterator.
-            view_iter = iter(view[:10])
-            eq_(len(view_iter), 10)  # sanity check
-            eq_(len(list(view_iter)), 10)
-            eq_(len(list(view_iter)), 10)
-
-            # Test frame selection
-            with assert_raises(IndexError):
-                view[len(view)]
-            eq_(view[0].configuration.step, view[0].configuration.step)
-            eq_(view[len(view) - 1].configuration.step, view[-1].configuration.step)
-
-def test_truncate():
-    with tempfile.TemporaryDirectory() as d:
-        gsd.hoomd.create(name=d+"/test_iteration.gsd");
-
-        with gsd.fl.GSDFile(name=d+"/test_iteration.gsd", mode='wb') as f:
-            hf = gsd.hoomd.HOOMDTrajectory(f);
-            hf.extend((create_frame(i) for i in range(20)));
-
-            eq_(len(hf), 20);
-            s = hf[10];
-            ok_(hf._initial_frame is not None);
-
-            hf.truncate();
-            eq_(len(hf), 0);
-            ok_(hf._initial_frame is None);
-
-def test_state():
-    with tempfile.TemporaryDirectory() as d:
-        snap0 = gsd.hoomd.Snapshot();
-
-        snap0.state['hpmc/sphere/radius'] = [2.0]
-        snap0.state['hpmc/sphere/orientable'] = [1]
-
-
-        snap1 = gsd.hoomd.Snapshot();
-
-        snap1.state['hpmc/convex_polyhedron/N'] = [3]
-        snap1.state['hpmc/convex_polyhedron/vertices'] = [[-1, -1, -1],
-                                                          [0, 1, 1],
-                                                          [1, 0, 0]];
-
-        gsd.hoomd.create(name=d+"/test_state.gsd");
-
-        with gsd.fl.GSDFile(name=d+"/test_state.gsd", mode='wb') as f:
-            hf = gsd.hoomd.HOOMDTrajectory(f);
-            hf.extend([snap0, snap1]);
-
-        with gsd.fl.GSDFile(name=d+"/test_state.gsd", mode='rb') as f:
-            hf = gsd.hoomd.HOOMDTrajectory(f);
-            eq_(len(hf), 2);
-            s = hf.read_frame(0);
-
-            numpy.testing.assert_array_equal(s.state['hpmc/sphere/radius'], snap0.state['hpmc/sphere/radius']);
-            numpy.testing.assert_array_equal(s.state['hpmc/sphere/orientable'], snap0.state['hpmc/sphere/orientable']);
-
-            s = hf.read_frame(1);
-
-            numpy.testing.assert_array_equal(s.state['hpmc/convex_polyhedron/N'], snap1.state['hpmc/convex_polyhedron/N']);
-            numpy.testing.assert_array_equal(s.state['hpmc/convex_polyhedron/vertices'], snap1.state['hpmc/convex_polyhedron/vertices']);
+def test_extend(tmp_path):
+    snap = gsd.hoomd.Snapshot();
+    snap.particles.N = 10;
+
+    with gsd.hoomd.open(name=tmp_path / "test_extend.gsd", mode='wb') as hf:
+        hf.extend((create_frame(i) for i in range(5)));
+
+    with gsd.hoomd.open(name=tmp_path / "test_extend.gsd", mode='rb') as hf:
+        assert len(hf) == 5;
+
+def test_defaults(tmp_path):
+    snap = gsd.hoomd.Snapshot();
+    snap.particles.N = 2;
+    snap.bonds.N = 3;
+    snap.angles.N = 4;
+    snap.dihedrals.N = 5;
+    snap.impropers.N = 6;
+    snap.constraints.N = 4;
+    snap.pairs.N = 7;
+
+    with gsd.hoomd.open(name=tmp_path / "test_defaults.gsd", mode='wb') as hf:
+        hf.append(snap);
+
+    with gsd.hoomd.open(name=tmp_path / "test_defaults.gsd", mode='rb') as hf:
+        s = hf.read_frame(0);
+
+        assert s.configuration.step == 0;
+        assert s.configuration.dimensions == 3;
+        numpy.testing.assert_array_equal(s.configuration.box, numpy.array([1,1,1,0,0,0], dtype=numpy.float32));
+        assert s.particles.N == 2;
+        assert s.particles.types == ['A'];
+        numpy.testing.assert_array_equal(s.particles.typeid, numpy.array([0,0], dtype=numpy.uint32));
+        numpy.testing.assert_array_equal(s.particles.mass, numpy.array([1,1], dtype=numpy.float32));
+        numpy.testing.assert_array_equal(s.particles.diameter, numpy.array([1,1], dtype=numpy.float32));
+        numpy.testing.assert_array_equal(s.particles.body, numpy.array([-1,-1], dtype=numpy.int32));
+        numpy.testing.assert_array_equal(s.particles.charge, numpy.array([0,0], dtype=numpy.float32));
+        numpy.testing.assert_array_equal(s.particles.moment_inertia, numpy.array([[0,0,0],[0,0,0]], dtype=numpy.float32));
+        numpy.testing.assert_array_equal(s.particles.position, numpy.array([[0,0,0],[0,0,0]], dtype=numpy.float32));
+        numpy.testing.assert_array_equal(s.particles.orientation, numpy.array([[1,0,0,0],[1,0,0,0]], dtype=numpy.float32));
+        numpy.testing.assert_array_equal(s.particles.velocity, numpy.array([[0,0,0],[0,0,0]], dtype=numpy.float32));
+        numpy.testing.assert_array_equal(s.particles.angmom, numpy.array([[0,0,0,0],[0,0,0,0]], dtype=numpy.float32));
+        numpy.testing.assert_array_equal(s.particles.image, numpy.array([[0,0,0],[0,0,0]], dtype=numpy.int32));
+
+        assert s.bonds.N == 3;
+        assert s.bonds.types == [];
+        numpy.testing.assert_array_equal(s.bonds.typeid, numpy.array([0,0,0], dtype=numpy.uint32));
+        numpy.testing.assert_array_equal(s.bonds.group, numpy.array([[0,0],[0,0],[0,0]], dtype=numpy.uint32));
+
+        assert s.angles.N == 4;
+        assert s.angles.types == [];
+        numpy.testing.assert_array_equal(s.angles.typeid, numpy.array([0,0,0,0], dtype=numpy.uint32));
+        numpy.testing.assert_array_equal(s.angles.group, numpy.array([[0,0,0],[0,0,0],[0,0,0],[0,0,0]], dtype=numpy.uint32));
+
+        assert s.dihedrals.N == 5;
+        assert s.dihedrals.types == [];
+        numpy.testing.assert_array_equal(s.dihedrals.typeid, numpy.array([0,0,0,0,0], dtype=numpy.uint32));
+        numpy.testing.assert_array_equal(s.dihedrals.group, numpy.array([[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0]], dtype=numpy.uint32));
+
+        assert s.impropers.N == 6;
+        assert s.impropers.types == [];
+        numpy.testing.assert_array_equal(s.impropers.typeid, numpy.array([0,0,0,0,0,0], dtype=numpy.uint32));
+        numpy.testing.assert_array_equal(s.impropers.group, numpy.array([[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0]], dtype=numpy.uint32));
+
+        assert s.constraints.N == 4;
+        numpy.testing.assert_array_equal(s.constraints.value, numpy.array([0,0,0,0], dtype=numpy.float32));
+        numpy.testing.assert_array_equal(s.constraints.group, numpy.array([[0,0],[0,0],[0,0], [0,0]], dtype=numpy.uint32));
+
+        assert s.pairs.N == 7;
+        assert s.pairs.types == [];
+        numpy.testing.assert_array_equal(s.pairs.typeid, numpy.array([0]*7, dtype=numpy.uint32));
+        numpy.testing.assert_array_equal(s.pairs.group, numpy.array([[0,0]]*7, dtype=numpy.uint32));
+
+        assert len(s.state) == 0
+
+def test_fallback(tmp_path):
+    snap0 = gsd.hoomd.Snapshot();
+    snap0.configuration.step = 10000;
+    snap0.configuration.dimensions = 2;
+    snap0.configuration.box = [4,5,6,1.0,0.5,0.25];
+    snap0.particles.N = 2;
+    snap0.particles.types = ['A', 'B', 'C']
+    snap0.particles.typeid = [1,2];
+    snap0.particles.mass = [2,3];
+    snap0.particles.diameter = [3,4];
+    snap0.particles.body = [10, 20];
+    snap0.particles.charge = [0.5, 0.25];
+    snap0.particles.moment_inertia = [[1,2,3], [3,2,1]];
+    snap0.particles.position = [[0.1, 0.2, 0.3], [-1.0, -2.0, -3.0]];
+    snap0.particles.orientation = [[1, 0.1, 0.2, 0.3], [0, -1.0, -2.0, -3.0]];
+    snap0.particles.velocity = [[1.1, 2.2, 3.3], [-3.3, -2.2, -1.1]];
+    snap0.particles.angmom = [[1, 1.1, 2.2, 3.3], [-1, -3.3, -2.2, -1.1]];
+    snap0.particles.image = [[10, 20, 30], [5, 6, 7]];
+
+    snap0.bonds.N = 1;
+    snap0.bonds.types = ['bondA', 'bondB']
+    snap0.bonds.typeid = [1];
+    snap0.bonds.group = [[0,1]];
+
+    snap0.angles.N = 1;
+    snap0.angles.typeid = [2];
+    snap0.angles.types = ['angleA', 'angleB']
+    snap0.angles.group = [[0,1, 0]];
+
+    snap0.dihedrals.N = 1;
+    snap0.dihedrals.typeid = [3];
+    snap0.dihedrals.types = ['dihedralA', 'dihedralB']
+    snap0.dihedrals.group = [[0,1, 1, 0]];
+
+    snap0.impropers.N = 1;
+    snap0.impropers.typeid = [4];
+    snap0.impropers.types = ['improperA', 'improperB']
+    snap0.impropers.group = [[1, 0, 0, 1]];
+
+    snap0.constraints.N = 1;
+    snap0.constraints.value = [1.1];
+    snap0.constraints.group = [[0,1]];
+
+    snap0.pairs.N = 1;
+    snap0.pairs.types = ['pairA', 'pairB']
+    snap0.pairs.typeid = [1];
+    snap0.pairs.group = [[0,3]];
+
+    snap1 = gsd.hoomd.Snapshot();
+    snap1.particles.N = 2;
+    snap1.particles.position = [[-2, -1, 0], [1, 3.0, 0.5]];
+
+    snap2 = gsd.hoomd.Snapshot();
+    snap2.particles.N = 3;
+    snap2.particles.types = ['q', 's'];
+    snap2.bonds.N = 3;
+    snap2.angles.N = 4;
+    snap2.dihedrals.N = 5;
+    snap2.impropers.N = 6;
+    snap2.constraints.N = 4;
+    snap2.pairs.N = 7;
+
+    with gsd.hoomd.open(name=tmp_path / "test_fallback.gsd", mode='wb') as hf:
+        hf.extend([snap0, snap1, snap2]);
+
+    with gsd.hoomd.open(name=tmp_path / "test_fallback.gsd", mode='rb') as hf:
+        assert len(hf) == 3;
+        s = hf.read_frame(0);
+
+        assert s.configuration.step == snap0.configuration.step;
+        assert s.configuration.dimensions == snap0.configuration.dimensions;
+        numpy.testing.assert_array_equal(s.configuration.box, snap0.configuration.box);
+        assert s.particles.N == snap0.particles.N;
+        assert s.particles.types == snap0.particles.types;
+        numpy.testing.assert_array_equal(s.particles.typeid, snap0.particles.typeid);
+        numpy.testing.assert_array_equal(s.particles.mass, snap0.particles.mass);
+        numpy.testing.assert_array_equal(s.particles.diameter, snap0.particles.diameter);
+        numpy.testing.assert_array_equal(s.particles.body, snap0.particles.body);
+        numpy.testing.assert_array_equal(s.particles.charge, snap0.particles.charge);
+        numpy.testing.assert_array_equal(s.particles.moment_inertia, snap0.particles.moment_inertia);
+        numpy.testing.assert_array_equal(s.particles.position, snap0.particles.position);
+        numpy.testing.assert_array_equal(s.particles.orientation, snap0.particles.orientation);
+        numpy.testing.assert_array_equal(s.particles.velocity, snap0.particles.velocity);
+        numpy.testing.assert_array_equal(s.particles.angmom, snap0.particles.angmom);
+        numpy.testing.assert_array_equal(s.particles.image, snap0.particles.image);
+
+        assert s.bonds.N == snap0.bonds.N;
+        assert s.bonds.types == snap0.bonds.types;
+        numpy.testing.assert_array_equal(s.bonds.typeid, snap0.bonds.typeid);
+        numpy.testing.assert_array_equal(s.bonds.group, snap0.bonds.group);
+
+        assert s.angles.N == snap0.angles.N;
+        assert s.angles.types == snap0.angles.types;
+        numpy.testing.assert_array_equal(s.angles.typeid, snap0.angles.typeid);
+        numpy.testing.assert_array_equal(s.angles.group, snap0.angles.group);
+
+        assert s.dihedrals.N == snap0.dihedrals.N;
+        assert s.dihedrals.types == snap0.dihedrals.types;
+        numpy.testing.assert_array_equal(s.dihedrals.typeid, snap0.dihedrals.typeid);
+        numpy.testing.assert_array_equal(s.dihedrals.group, snap0.dihedrals.group);
+
+        assert s.impropers.N == snap0.impropers.N;
+        assert s.impropers.types == snap0.impropers.types;
+        numpy.testing.assert_array_equal(s.impropers.typeid, snap0.impropers.typeid);
+        numpy.testing.assert_array_equal(s.impropers.group, snap0.impropers.group);
+
+        assert s.constraints.N == snap0.constraints.N;
+        numpy.testing.assert_array_equal(s.constraints.value, snap0.constraints.value);
+        numpy.testing.assert_array_equal(s.constraints.group, snap0.constraints.group);
+
+        assert s.pairs.N == snap0.pairs.N;
+        assert s.pairs.types == snap0.pairs.types;
+        numpy.testing.assert_array_equal(s.pairs.typeid, snap0.pairs.typeid);
+        numpy.testing.assert_array_equal(s.pairs.group, snap0.pairs.group);
+
+        # test that everything but position remained the same in frame 1
+        s = hf.read_frame(1);
+
+        assert s.configuration.step == snap0.configuration.step;
+        assert s.configuration.dimensions == snap0.configuration.dimensions;
+        numpy.testing.assert_array_equal(s.configuration.box, snap0.configuration.box);
+        assert s.particles.N == snap0.particles.N;
+        assert s.particles.types == snap0.particles.types;
+        numpy.testing.assert_array_equal(s.particles.typeid, snap0.particles.typeid);
+        numpy.testing.assert_array_equal(s.particles.mass, snap0.particles.mass);
+        numpy.testing.assert_array_equal(s.particles.diameter, snap0.particles.diameter);
+        numpy.testing.assert_array_equal(s.particles.body, snap0.particles.body);
+        numpy.testing.assert_array_equal(s.particles.charge, snap0.particles.charge);
+        numpy.testing.assert_array_equal(s.particles.moment_inertia, snap0.particles.moment_inertia);
+        numpy.testing.assert_array_equal(s.particles.position, snap1.particles.position);
+        numpy.testing.assert_array_equal(s.particles.orientation, snap0.particles.orientation);
+        numpy.testing.assert_array_equal(s.particles.velocity, snap0.particles.velocity);
+        numpy.testing.assert_array_equal(s.particles.angmom, snap0.particles.angmom);
+        numpy.testing.assert_array_equal(s.particles.image, snap0.particles.image);
+
+        assert s.bonds.N == snap0.bonds.N;
+        assert s.bonds.types == snap0.bonds.types;
+        numpy.testing.assert_array_equal(s.bonds.typeid, snap0.bonds.typeid);
+        numpy.testing.assert_array_equal(s.bonds.group, snap0.bonds.group);
+
+        assert s.angles.N == snap0.angles.N;
+        assert s.angles.types == snap0.angles.types;
+        numpy.testing.assert_array_equal(s.angles.typeid, snap0.angles.typeid);
+        numpy.testing.assert_array_equal(s.angles.group, snap0.angles.group);
+
+        assert s.dihedrals.N == snap0.dihedrals.N;
+        assert s.dihedrals.types == snap0.dihedrals.types;
+        numpy.testing.assert_array_equal(s.dihedrals.typeid, snap0.dihedrals.typeid);
+        numpy.testing.assert_array_equal(s.dihedrals.group, snap0.dihedrals.group);
+
+        assert s.impropers.N == snap0.impropers.N;
+        assert s.impropers.types == snap0.impropers.types;
+        numpy.testing.assert_array_equal(s.impropers.typeid, snap0.impropers.typeid);
+        numpy.testing.assert_array_equal(s.impropers.group, snap0.impropers.group);
+
+        assert s.constraints.N == snap0.constraints.N;
+        numpy.testing.assert_array_equal(s.constraints.value, snap0.constraints.value);
+        numpy.testing.assert_array_equal(s.constraints.group, snap0.constraints.group);
+
+        assert s.pairs.N == snap0.pairs.N;
+        assert s.pairs.types == snap0.pairs.types;
+        numpy.testing.assert_array_equal(s.pairs.typeid, snap0.pairs.typeid);
+        numpy.testing.assert_array_equal(s.pairs.group, snap0.pairs.group);
+
+        # check that the third frame goes back to defaults because it has a different N
+        s = hf.read_frame(2);
+
+        assert s.particles.N == 3;
+        assert s.particles.types == ['q', 's'];
+        numpy.testing.assert_array_equal(s.particles.typeid, numpy.array([0,0,0], dtype=numpy.uint32));
+        numpy.testing.assert_array_equal(s.particles.mass, numpy.array([1,1,1], dtype=numpy.float32));
+        numpy.testing.assert_array_equal(s.particles.diameter, numpy.array([1,1,1], dtype=numpy.float32));
+        numpy.testing.assert_array_equal(s.particles.body, numpy.array([-1,-1,-1], dtype=numpy.float32));
+        numpy.testing.assert_array_equal(s.particles.charge, numpy.array([0,0,0], dtype=numpy.float32));
+        numpy.testing.assert_array_equal(s.particles.moment_inertia, numpy.array([[0,0,0],[0,0,0],[0,0,0]], dtype=numpy.float32));
+        numpy.testing.assert_array_equal(s.particles.position, numpy.array([[0,0,0],[0,0,0],[0,0,0]], dtype=numpy.float32));
+        numpy.testing.assert_array_equal(s.particles.orientation, numpy.array([[1,0,0,0],[1,0,0,0],[1,0,0,0]], dtype=numpy.float32));
+        numpy.testing.assert_array_equal(s.particles.velocity, numpy.array([[0,0,0],[0,0,0],[0,0,0]], dtype=numpy.float32));
+        numpy.testing.assert_array_equal(s.particles.angmom, numpy.array([[0,0,0,0],[0,0,0,0],[0,0,0,0]], dtype=numpy.float32));
+        numpy.testing.assert_array_equal(s.particles.image, numpy.array([[0,0,0],[0,0,0],[0,0,0]], dtype=numpy.int32));
+
+        assert s.bonds.N == 3;
+        assert s.bonds.types == snap0.bonds.types;
+        numpy.testing.assert_array_equal(s.bonds.typeid, numpy.array([0,0,0], dtype=numpy.uint32));
+        numpy.testing.assert_array_equal(s.bonds.group, numpy.array([[0,0],[0,0],[0,0]], dtype=numpy.uint32));
+
+        assert s.angles.N == 4;
+        assert s.angles.types == snap0.angles.types;
+        numpy.testing.assert_array_equal(s.angles.typeid, numpy.array([0,0,0,0], dtype=numpy.uint32));
+        numpy.testing.assert_array_equal(s.angles.group, numpy.array([[0,0,0],[0,0,0],[0,0,0],[0,0,0]], dtype=numpy.uint32));
+
+        assert s.dihedrals.N == 5;
+        assert s.dihedrals.types == snap0.dihedrals.types;
+        numpy.testing.assert_array_equal(s.dihedrals.typeid, numpy.array([0,0,0,0,0], dtype=numpy.uint32));
+        numpy.testing.assert_array_equal(s.dihedrals.group, numpy.array([[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0]], dtype=numpy.uint32));
+
+        assert s.impropers.N == 6;
+        assert s.impropers.types == snap0.impropers.types;
+        numpy.testing.assert_array_equal(s.impropers.typeid, numpy.array([0,0,0,0,0,0], dtype=numpy.uint32));
+        numpy.testing.assert_array_equal(s.impropers.group, numpy.array([[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0]], dtype=numpy.uint32));
+
+        assert s.constraints.N == 4;
+        numpy.testing.assert_array_equal(s.constraints.value, numpy.array([0,0,0,0], dtype=numpy.float32));
+        numpy.testing.assert_array_equal(s.constraints.group, numpy.array([[0,0],[0,0],[0,0], [0,0]], dtype=numpy.uint32));
+
+        assert s.pairs.N == 7;
+        assert s.pairs.types == snap0.pairs.types;
+        numpy.testing.assert_array_equal(s.pairs.typeid, numpy.array([0]*7, dtype=numpy.uint32));
+        numpy.testing.assert_array_equal(s.pairs.group, numpy.array([[0,0]]*7, dtype=numpy.uint32));
+
+
+def test_fallback2(tmp_path):
+    snap0 = gsd.hoomd.Snapshot();
+    snap0.configuration.step = 1;
+    snap0.configuration.dimensions = 3;
+    snap0.particles.N = 2;
+    snap0.particles.mass = [2,3];
+
+    snap1 = gsd.hoomd.Snapshot();
+    snap1.configuration.step = 2;
+    snap1.particles.N = 2;
+    snap1.particles.position = [[1,2,3],[4,5,6]];
+
+    with gsd.hoomd.open(name=tmp_path / "test_fallback2.gsd", mode='wb') as hf:
+        hf.extend([snap0, snap1]);
+
+    with gsd.hoomd.open(name=tmp_path / "test_fallback2.gsd", mode='rb') as hf:
+        assert len(hf) == 2;
+
+        s = hf.read_frame(1);
+        numpy.testing.assert_array_equal(s.particles.mass, snap0.particles.mass);
+
+def test_iteration(tmp_path):
+    with gsd.hoomd.open(name=tmp_path / "test_iteration.gsd", mode='wb') as hf:
+        hf.extend((create_frame(i) for i in range(20)));
+
+    with gsd.hoomd.open(name=tmp_path / "test_iteration.gsd", mode='rb') as hf:
+        step = hf[-1].configuration.step;
+        assert step == 20;
+
+        step = hf[-2].configuration.step;
+        assert step == 19;
+
+        step = hf[-3].configuration.step;
+        assert step == 18;
+
+        step = hf[0].configuration.step;
+        assert step == 1;
+
+        step = hf[-20].configuration.step;
+        assert step == 1;
+
+        with pytest.raises(IndexError) as cm:
+            step = hf[-21].configuration.step;
+
+        with pytest.raises(IndexError) as cm:
+            step = hf[20]
+
+        snaps = hf[5:10];
+        steps = [snap.configuration.step for snap in snaps];
+        assert steps == [6,7,8,9,10];
+
+        snaps = hf[15:50];
+        steps = [snap.configuration.step for snap in snaps];
+        assert steps == [16,17,18,19,20];
+
+        snaps = hf[15:-3];
+        steps = [snap.configuration.step for snap in snaps];
+        assert steps == [16,17];
+
+def test_slicing_and_iteration(tmp_path):
+    with gsd.hoomd.open(name=tmp_path / "test_slicing.gsd", mode='wb') as hf:
+        hf.extend((create_frame(i) for i in range(20)));
+
+    with gsd.hoomd.open(name=tmp_path / "test_slicing.gsd", mode='rb') as hf:
+        # Test len()-function on trajectory and sliced trajectory.
+        assert len(hf) == 20
+        assert len(hf[:10]) == 10
+
+        # Test len()-function with explicit iterator.
+        assert len(iter(hf)) == len(hf)
+        assert len(iter(hf[:10])) == len(hf[:10])
+
+        # Test iteration with implicit iterator.
+        # All iterations are run twice to check for issues
+        # with iterator exhaustion.
+        assert len(list(hf)) == len(hf)
+        assert len(list(hf)) == len(hf)
+        assert len(list(hf[:10])) == len(hf[:10])
+        assert len(list(hf[:10])) == len(hf[:10])
+
+        # Test iteration with explicit iterator.
+        hf_iter = iter(hf)
+        assert len(hf_iter) == len(hf)  # sanity check
+        assert len(list(hf_iter)) == len(hf)
+        assert len(list(hf_iter)) == len(hf)
+
+        # Test iteration with explicit sliced iterator.
+        hf_iter = iter(hf[:10])
+        assert len(hf_iter) == 10  # sanity check
+        assert len(list(hf_iter)) == 10
+        assert len(list(hf_iter)) == 10
+
+        # Test frame selection
+        with pytest.raises(IndexError):
+            hf[len(hf)]
+        assert hf[0].configuration.step == hf[0].configuration.step
+        assert hf[len(hf) - 1].configuration.step == hf[-1].configuration.step
+
+
+def test_view_slicing_and_iteration(tmp_path):
+    with gsd.hoomd.open(name=tmp_path / "test_slicing.gsd", mode='wb') as hf:
+        hf.extend((create_frame(i) for i in range(40)));
+
+    with gsd.hoomd.open(name=tmp_path / "test_slicing.gsd", mode='rb') as hf:
+        view = hf[::2]
+
+        # Test len()-function on trajectory and sliced view.
+        assert len(view) == 20
+        assert len(view[:10]) == 10
+        assert len(view[::2]) == 10
+
+        # Test len()-function with explicit iterator.
+        assert len(iter(view)) == len(view)
+        assert len(iter(view[:10])) == len(view[:10])
+
+        # Test iteration with implicit iterator.
+        # All iterations are run twice to check for issues
+        # with iterator exhaustion.
+        assert len(list(view)) == len(view)
+        assert len(list(view)) == len(view)
+        assert len(list(view[:10])) == len(view[:10])
+        assert len(list(view[:10])) == len(view[:10])
+        assert len(list(view[::2])) == len(view[::2])
+        assert len(list(view[::2])) == len(view[::2])
+
+        # Test iteration with explicit iterator.
+        view_iter = iter(view)
+        assert len(view_iter) == len(view)  # sanity check
+        assert len(list(view_iter)) == len(view)
+        assert len(list(view_iter)) == len(view)
+
+        # Test iteration with explicit sliced iterator.
+        view_iter = iter(view[:10])
+        assert len(view_iter) == 10  # sanity check
+        assert len(list(view_iter)) == 10
+        assert len(list(view_iter)) == 10
+
+        # Test frame selection
+        with pytest.raises(IndexError):
+            view[len(view)]
+        assert view[0].configuration.step == view[0].configuration.step
+        assert view[len(view) - 1].configuration.step == view[-1].configuration.step
+
+def test_truncate(tmp_path):
+    with gsd.hoomd.open(name=tmp_path / "test_iteration.gsd", mode='wb') as hf:
+        hf.extend((create_frame(i) for i in range(20)));
+
+        assert len(hf) == 20;
+        s = hf[10];
+        assert hf._initial_frame is not None;
+
+        hf.truncate();
+        assert len(hf) == 0;
+        assert hf._initial_frame is None;
+
+def test_state(tmp_path):
+    snap0 = gsd.hoomd.Snapshot();
+
+    snap0.state['hpmc/sphere/radius'] = [2.0]
+    snap0.state['hpmc/sphere/orientable'] = [1]
+
+
+    snap1 = gsd.hoomd.Snapshot();
+
+    snap1.state['hpmc/convex_polyhedron/N'] = [3]
+    snap1.state['hpmc/convex_polyhedron/vertices'] = [[-1, -1, -1],
+                                                      [0, 1, 1],
+                                                      [1, 0, 0]];
+
+    with gsd.hoomd.open(name=tmp_path / "test_state.gsd", mode='wb') as hf:
+        hf.extend([snap0, snap1]);
+
+    with gsd.hoomd.open(name=tmp_path / "test_state.gsd", mode='rb') as hf:
+        assert len(hf) == 2;
+        s = hf.read_frame(0);
+
+        numpy.testing.assert_array_equal(s.state['hpmc/sphere/radius'], snap0.state['hpmc/sphere/radius']);
+        numpy.testing.assert_array_equal(s.state['hpmc/sphere/orientable'], snap0.state['hpmc/sphere/orientable']);
+
+        s = hf.read_frame(1);
+
+        numpy.testing.assert_array_equal(s.state['hpmc/convex_polyhedron/N'], snap1.state['hpmc/convex_polyhedron/N']);
+        numpy.testing.assert_array_equal(s.state['hpmc/convex_polyhedron/vertices'], snap1.state['hpmc/convex_polyhedron/vertices']);


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
* Simplify test code using pytest fixtures and parameterize features.
* Support `pathlib` paths

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Pytest removed yield based tests, this prevented new versions of pytest from running all of gsd's tests. Going forward, pytest's fixture and parameterize features greatly simplify the test code, making it easier to read and write - at the expense of requiring pytest for testing and no longer supporting nose.

Specifically, pytest >= 3.9 is needed for `tmp_path` support.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
CI tests pass with pytest 5.

## Change log

<!-- Propose a change log entry. -->
```
* pytest >= 3.9.0 is required to run unit tests
* ``gsd.fl.open`` and ``gsd.hoomd.open`` accept objects implementing ``os.PathLike``
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/gsd/blob/master/doc/credits.rst).
- [ ] I am a member of the [gsd-contributors team](https://github.com/orgs/glotzerlab/teams/gsd-contributors/members).
