### PR TITLE
Fix corrupt indices

### DIFF
--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -34,6 +34,7 @@
 #define read _read
 #define open _open
 #define ftruncate _chsize
+#define fsync _commit
 
 int S_IRUSR = _S_IREAD;
 int S_IWUSR = _S_IWRITE;


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Handle corrupt indices better.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Files with corrupt indices in some cases identified billions of frames in the file. This PR detects these files as corrupt on open. Furthermore, it adds ``fsync`` calls when updating the index to hopefully prevent gsd from writing such corrupt indicies.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Basic CI tests pass. I also manually tested this against the corrupt sample file provided by a user. There is no reliable way to test if the ``fsync`` calls prevent this type of corruption.

## Change log

<!-- Propose a change log entry. -->
```
- Additional checks for corrupt GSD files.
- Synchronize after expanding file index.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/gsd/blob/master/doc/credits.rst).
- [ ] I am a member of the [gsd-contributors team](https://github.com/orgs/glotzerlab/teams/gsd-contributors/members).
