### PR TITLE
Feature/mmap index only

### DIFF
--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -392,7 +392,7 @@ int __gsd_read_header(struct gsd_handle* handle)
         // in append mode, we want to avoid reading the entire index in memory, but we also don't want to bother
         // keeping the mapping up to date. Map the index for now to determine index_num_entries, but then
         // unmap it and use different logic to manage a cache of only unwritten index entries
-        handle->index = mmap(NULL, sizeof(struct gsd_index_entry) * handle->header.index_allocated_entries, PROT_READ, MAP_SHARED, handle->fd, handle->header.index_location);
+        handle->index = (struct gsd_index_entry *) mmap(NULL, sizeof(struct gsd_index_entry) * handle->header.index_allocated_entries, PROT_READ, MAP_SHARED, handle->fd, handle->header.index_location);
 
         if (handle->index == MAP_FAILED)
             return -1;


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

When operating in read-only mode, instead of memory mapping the entire file only the index and namelist are mapped.

## Motivation and Context

On systems with limited virtual memory it may not be possible to create enough memory pages to hold a large GSD file.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves: #41 

## How Has This Been Tested?

Existing tests only.

## Change log

<!-- Propose a change log entry. -->
```
Only the index and namelist are memory mapped when operating in read-only mode to avoid exhausting virtual memory.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/gsd/blob/master/doc/credits.rst).
- [x] I am a member of the [gsd-contributors team](https://github.com/orgs/glotzerlab/teams/gsd-contributors/members).
