### PR TITLE
Error when attempting to write chunks with invalid names

### DIFF
--- a/gsd/fl.pyx
+++ b/gsd/fl.pyx
@@ -523,6 +523,8 @@ cdef class GSDFile:
             raise IOError(*__format_errno(name));
         elif retval == -2:
             raise RuntimeError("GSD file is opened read only: " + self.name);
+        elif retval == -3:
+            raise RuntimeError("Name list full: " + self.name);
         elif retval != 0:
             raise RuntimeError("Unknown error");
 

--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -834,7 +834,7 @@ int gsd_end_frame(struct gsd_handle* handle)
 
     \post The given data chunk is written to the end of the file and its location is updated in the in-memory index.
 
-    \return 0 on success, -1 on a file IO failure - see errno for details, and -2 on invalid input
+    \return 0 on success, -1 on a file IO failure - see errno for details, -2 on invalid input, and -3 when out of names
 */
 int gsd_write_chunk(struct gsd_handle* handle,
                     const char *name,
@@ -857,6 +857,8 @@ int gsd_write_chunk(struct gsd_handle* handle,
     memset(&index_entry, 0, sizeof(index_entry));
     index_entry.frame = handle->cur_frame;
     index_entry.id = __gsd_get_id(handle, name, 1);
+    if (index_entry.id == UINT16_MAX)
+        return -3;
     index_entry.type = (uint8_t)type;
     index_entry.N = N;
     index_entry.M = M;

--- a/tests/test_fl.py
+++ b/tests/test_fl.py
@@ -368,3 +368,13 @@ def test_find_matching_chunk_names(tmp_path):
 
         other_chunks = f.find_matching_chunk_names('other/');
         assert len(other_chunks) == 0;
+
+def test_chunk_name_limit(tmp_path):
+    with gsd.fl.open(name=tmp_path / 'test.gsd', mode='xb', application='test_chunk_name_limit', schema='none', schema_version=[1,2]) as f:
+        for i in range(128):
+            f.write_chunk(name=str(i), data=numpy.array([i], dtype=numpy.int32))
+
+        # A bug in GSD limits files to 128 chunk names:
+        # see https://github.com/glotzerlab/gsd/issues/43
+        with pytest.raises(Exception) as cm:
+            f.write_chunk(name='128', data=numpy.array([i], dtype=numpy.int32))


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Return an error when attempting to write a chunk that fails to allocate a name.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
A bug in GSD prevents the use of more than 128 chunk names #43, but writes of additional chunk names silently fail.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Added unit test.

## Change log

<!-- Propose a change log entry. -->
```
* Report an error when attempting to write a chunk that fails to allocate a name.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/gsd/blob/master/doc/credits.rst).
- [ ] I am a member of the [gsd-contributors team](https://github.com/orgs/glotzerlab/teams/gsd-contributors/members).
