### PR TITLE
add sphere union spec

### DIFF
--- a/doc/shapes.rst
+++ b/doc/shapes.rst
@@ -137,3 +137,26 @@ Example::
         "vertices": [[0.5, 0.5, 0.5], [0.5, -0.5, -0.5], [-0.5, 0.5, -0.5], [-0.5, -0.5, 0.5]],
         "indices": [[0, 1, 2], [0, 3, 1], [0, 2, 3], [1, 3, 2]]
     }
+
+Sphere unions
+-------------
+
+Type: ``SphereUnion``
+
+A collection of spheres, defined by their radii and positions.
+
+=============== =============== ===== ==== ======= ======
+Key             Description     Type  Size Default Units
+=============== =============== ===== ==== ======= ======
+radii           Sphere radii    float Nx1          length
+centers         Sphere centers  float Nx3          length
+=============== =============== ===== ==== ======= ======
+
+Example::
+
+    {
+        "type": "SphereUnion",
+        "centers": [[0, 0, 1.0], [0, 1.0, 0], [1.0, 0, 0]]
+        "radii": [0.5, 0.5, 0.5]
+    }
+


### PR DESCRIPTION
## Description

We should support sphere unions in gsd, for downstream visualization in ovito.

## Motivation and Context

Visualize more complex shapes, such as proteins

## How Has This Been Tested?

Built documentation, looks ok.

## Change log

```
Add shape spec for sphere unions
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/gsd/blob/master/doc/credits.rst).
