### PR TITLE
Show defaults in gsd.fl.open.

### DIFF
--- a/gsd/fl.pyx
+++ b/gsd/fl.pyx
@@ -148,7 +148,7 @@ cdef void * __get_ptr_float64(data):
 
 
 def open(name, mode, application=None, schema=None, schema_version=None):
-    """ open(name, mode, application, schema, schema_version)
+    """ open(name, mode, application=None, schema=None, schema_version=None)
 
     :py:func:`open` opens a GSD file and returns a :py:class:`GSDFile` instance.
     The return value of :py:func:`open` can be used as a context manager.


### PR DESCRIPTION
## Description

Minor change to docs of `gsd.fl.open`, so that the keyword arguments with default values show those defaults.

## Motivation and Context

I was confused when reading the docs.

## Change log

Not needed.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/gsd/blob/master/doc/credits.rst).
