### PR TITLE
Give ConfigurationData smart dimension default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ Change Log
 v2.x
 ----
 
+*Changed*
+
+* Make ``gsd.hoomd.ConfigurationData`` have smart ``dimensions`` default
+  based on box's :math:`L_z` value.
+
 v2.3.0 (2020-10-30)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/doc/schema-hoomd.rst
+++ b/doc/schema-hoomd.rst
@@ -129,7 +129,7 @@ Configuration
 
     .. note::
         When using `gsd.hoomd.Snapshot`, the object will try to intelligently default to a
-        dimension. If setting the box to a box where :math:`L_z = 0`, ``dimensions`` will default to
+        dimension. When setting a box with :math:`L_z = 0`, ``dimensions`` will default to
         2 otherwise 3. Explicit setting of this value by users always takes precedence.
 
 .. chunk:: configuration/box

--- a/doc/schema-hoomd.rst
+++ b/doc/schema-hoomd.rst
@@ -127,7 +127,7 @@ Configuration
 
     Number of dimensions in the simulation. Must be 2 or 3.
 
-    Note:
+    .. note::
         When using `gsd.hoomd.Snapshot`, the object will try to intelligently default to a
         dimension. If setting the box to a box where :math:`L_z = 0`, ``dimensions`` will default to
         2 otherwise 3. Explicit setting of this value by users always takes precedence.

--- a/doc/schema-hoomd.rst
+++ b/doc/schema-hoomd.rst
@@ -127,6 +127,11 @@ Configuration
 
     Number of dimensions in the simulation. Must be 2 or 3.
 
+    Note:
+        When using `gsd.hoomd.Snapshot`, the object will try to intelligently default to a
+        dimension. If setting the box to a box where :math:`L_z = 0`, ``dimensions`` will default to
+        2 otherwise 3. Explicit setting of this value by users always takes precedence.
+
 .. chunk:: configuration/box
 
     :Type: float

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -45,7 +45,10 @@ class ConfigurationData(object):
         step (int): Time step of this frame (:chunk:`configuration/step`).
 
         dimensions (int): Number of dimensions
-            (:chunk:`configuration/dimensions`).
+            (:chunk:`configuration/dimensions`). When not set explicitly,
+            dimensions will default to different values based on the value of
+            :math:`L_z` in `box`. When :math:`L_z = 0` dimensions will default
+            to 2, otherwise 3. User set values always take precedence.
 
         box ((6, 1) `numpy.ndarray` of ``numpy.float32``):
             Box dimensions (:chunk:`configuration/box`)

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -60,7 +60,22 @@ class ConfigurationData(object):
     def __init__(self):
         self.step = None
         self.dimensions = None
-        self.box = None
+        self._box = None
+
+    @property
+    def box(self):
+        return self._box
+
+    @box.setter
+    def box(self, box):
+        self._box = box
+        try:
+            Lz = box[2]
+        except TypeError:
+            return
+        else:
+            if self.dimensions is None:
+                self.dimensions = 2 if Lz == 0 else 3
 
     def validate(self):
         """Validate all attributes.

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -50,9 +50,7 @@ class ConfigurationData(object):
             :math:`L_z` in `box`. When :math:`L_z = 0` dimensions will default
             to 2, otherwise 3. User set values always take precedence.
 
-        box ((6, 1) `numpy.ndarray` of ``numpy.float32``):
-            Box dimensions (:chunk:`configuration/box`)
-            [lx, ly, lz, xy, xz, yz].
+
     """
 
     _default_value = OrderedDict()
@@ -67,6 +65,11 @@ class ConfigurationData(object):
 
     @property
     def box(self):
+        """((6, 1) `numpy.ndarray` of ``numpy.float32``): Box dimensions \
+        (:chunk:`configuration/box`).
+
+        [lx, ly, lz, xy, xz, yz].
+        """
         return self._box
 
     @box.setter


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Gives the `ConfigurationData` a smart `dimensions` default. Now when the box set to the object has a `Lz == 0`, if a user hasn't explicitly set `dimensions` it sets `dimensions` to 2. This is a change from previous behavior, but is not expected to break any workflows.

## Motivation and Context
This PR is designed to help make the package conform to a similar standard to HOOMD-blue v3 which treats boxes with `Lz == 0` as 2D. A recent user of HOOMD-blue v3 ran into the problem where specifying a 2D box according to the HOOMD-blue spec led to a GSD file with a 3 dimensional box with no length in the z dimension. This led to errors in the HOOMD-blue script trying to read from this GSD file. As in HOOMD-blue version 3 users are encouraged to create initialization files using gsd, we should try to mimic HOOMD-blue's version 3 behavior if possible.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Tested locally.

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

Already edited.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
