### PR TITLE
Remove wrong install_requires on cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(name='gsd',
           "Topic :: Scientific/Engineering :: Physics",
           ],
 
-      install_requires=['cython>=0.29.0,<1', 'numpy>=1.9.3,<2'],
+      install_requires=['numpy>=1.9.3,<2'],
       python_requires='~=3.5',
       ext_modules=extensions,
       packages=['gsd', 'gsd.test'],


### PR DESCRIPTION
## Description

Remove Cython from `install_requires`.

## Motivation and Context

Cython is used only at build time, and the resulting Python extensions do not need Cython installed. Its presence in `install_requires` means that it's unnecessarily required to be installed along with binary distributions and present at all time which is wrong.

## How Has This Been Tested?

By installing the package.

## Change log

```
*Changed*

* Cython is no longer listed incorrectly as an install requirement.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/master/ContributorAgreement.md).
- [ ] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.

^ this is a trivial `setup.py` change that doesn't affect the actual package's code. Should I really add myself to credits? ;-)