### PR TITLE
Fix angles, dihedrals, and impropers docs.

### DIFF
--- a/doc/schema-hoomd.rst
+++ b/doc/schema-hoomd.rst
@@ -403,8 +403,8 @@ Topology
 .. chunk:: angles/group
 
     :Type: uint32
-    :Size: Nx2
-    :Default: 0,0
+    :Size: Nx3
+    :Default: 0,0,0
     :Units: number
 
     Store the particle tags in each angle.
@@ -444,8 +444,8 @@ Topology
 .. chunk:: dihedrals/group
 
     :Type: uint32
-    :Size: Nx2
-    :Default: 0,0
+    :Size: Nx4
+    :Default: 0,0,0,0
     :Units: number
 
     Store the particle tags in each dihedral.
@@ -485,8 +485,8 @@ Topology
 .. chunk:: impropers/group
 
     :Type: uint32
-    :Size: Nx2
-    :Default: 0,0
+    :Size: Nx4
+    :Default: 0,0,0,0
     :Units: number
 
     Store the particle tags in each improper.


### PR DESCRIPTION
## Description

Fixed an error in the docs: the shapes of `angles/group`, `dihedrals/group`, and `impropers/group` should be `N, 3`, `N, 4`, and `N, 4`, respectively.

## Change log

<!-- Propose a change log entry. -->
```
- Fixed documented array shapes for angles, dihedrals, and impropers.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
