### PR TITLE
Deprecate read_frame

### DIFF
--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -825,7 +825,7 @@ class HOOMDTrajectory(object):
         frame 0 data to avoid file read overhead. Return any default data as
         non-writable numpy arrays.
 
-        .. deprecated: v2.5
+        .. deprecated:: v2.5
         """
         warnings.warn("Deprecated, trajectory[idx]", DeprecationWarning)
         return self._read_frame(idx)

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -21,6 +21,7 @@ import numpy
 from collections import OrderedDict
 import logging
 import json
+import warnings
 
 try:
     from gsd import fl
@@ -711,7 +712,7 @@ class HOOMDTrajectory(object):
         # want the initial frame specified as a reference to detect if chunks
         # need to be written
         if self._initial_frame is None and len(self) > 0:
-            self.read_frame(0)
+            self._read_frame(0)
 
         for path in [
                 'configuration',
@@ -823,14 +824,21 @@ class HOOMDTrajectory(object):
         from frame 0, or initialize from default values if not in frame 0. Cache
         frame 0 data to avoid file read overhead. Return any default data as
         non-writable numpy arrays.
+
+        .. deprecated: v2.5
         """
+        warnings.warn("Deprecated, trajectory[idx]", DeprecationWarning)
+        return self._read_frame(idx)
+
+    def _read_frame(self, idx):
+        """Implements read_frame."""
         if idx >= len(self):
             raise IndexError
 
         logger.debug('reading frame ' + str(idx) + ' from: ' + str(self.file))
 
         if self._initial_frame is None and idx != 0:
-            self.read_frame(0)
+            self._read_frame(0)
 
         snap = Snapshot()
         # read configuration first
@@ -986,7 +994,7 @@ class HOOMDTrajectory(object):
                 key += len(self)
             if key >= len(self) or key < 0:
                 raise IndexError()
-            return self.read_frame(key)
+            return self._read_frame(key)
         else:
             raise TypeError
 

--- a/gsd/test/test_hoomd.py
+++ b/gsd/test/test_hoomd.py
@@ -71,7 +71,7 @@ def test_defaults(tmp_path, open_mode):
 
     with gsd.hoomd.open(name=tmp_path / "test_defaults.gsd",
                         mode=open_mode.read) as hf:
-        s = hf.read_frame(0)
+        s = hf[0]
 
         assert s.configuration.step == 0
         assert s.configuration.dimensions == 3
@@ -254,7 +254,7 @@ def test_fallback(tmp_path, open_mode):
     with gsd.hoomd.open(name=tmp_path / "test_fallback.gsd",
                         mode=open_mode.read) as hf:
         assert len(hf) == 3
-        s = hf.read_frame(0)
+        s = hf[0]
 
         assert s.configuration.step == snap0.configuration.step
         assert s.configuration.dimensions == snap0.configuration.dimensions
@@ -322,7 +322,7 @@ def test_fallback(tmp_path, open_mode):
         numpy.testing.assert_array_equal(s.log['value'], snap0.log['value'])
 
         # test that everything but position remained the same in frame 1
-        s = hf.read_frame(1)
+        s = hf[1]
 
         assert s.configuration.step == snap0.configuration.step
         assert s.configuration.dimensions == snap0.configuration.dimensions
@@ -392,7 +392,7 @@ def test_fallback(tmp_path, open_mode):
 
         # check that the third frame goes back to defaults because it has a
         # different N
-        s = hf.read_frame(2)
+        s = hf[2]
 
         assert s.particles.N == 3
         assert s.particles.types == ['q', 's']
@@ -506,7 +506,7 @@ def test_fallback2(tmp_path, open_mode):
                         mode=open_mode.read) as hf:
         assert len(hf) == 2
 
-        s = hf.read_frame(1)
+        s = hf[1]
         numpy.testing.assert_array_equal(s.particles.mass, snap0.particles.mass)
 
 
@@ -678,14 +678,14 @@ def test_state(tmp_path, open_mode):
     with gsd.hoomd.open(name=tmp_path / "test_state.gsd",
                         mode=open_mode.read) as hf:
         assert len(hf) == 2
-        s = hf.read_frame(0)
+        s = hf[0]
 
         numpy.testing.assert_array_equal(s.state['hpmc/sphere/radius'],
                                          snap0.state['hpmc/sphere/radius'])
         numpy.testing.assert_array_equal(s.state['hpmc/sphere/orientable'],
                                          snap0.state['hpmc/sphere/orientable'])
 
-        s = hf.read_frame(1)
+        s = hf[1]
 
         numpy.testing.assert_array_equal(
             s.state['hpmc/convex_polyhedron/N'],
@@ -716,7 +716,7 @@ def test_log(tmp_path, open_mode):
     with gsd.hoomd.open(name=tmp_path / "test_log.gsd",
                         mode=open_mode.read) as hf:
         assert len(hf) == 2
-        s = hf.read_frame(0)
+        s = hf[0]
 
         numpy.testing.assert_array_equal(s.log['particles/net_force'],
                                          snap0.log['particles/net_force'])
@@ -727,7 +727,7 @@ def test_log(tmp_path, open_mode):
         numpy.testing.assert_array_equal(s.log['value/pressure'],
                                          snap0.log['value/pressure'])
 
-        s = hf.read_frame(1)
+        s = hf[1]
 
         # unspecified entries pull from frame 0
         numpy.testing.assert_array_equal(s.log['particles/net_force'],

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,8 +20,9 @@ max_doc_length = 80
 hang_closing = True
 docstring-convention=google
 rst-directives =
-    program
-    option
+    program,
+    option,
+    deprecated,
 rst-roles =
     file,
     py:mod,


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Deprecate the `read_frame` method.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This simplifies the API by providing only one user-facing method (`__getitem__`) for reading frames (or slices of frames from disk). `read_frame` was meant to be private when written and it was mistakenly made public.

#118 fixes the sphinx documentation to show `__getitem__` to users.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #117 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Unit tests pass. The deprecation warning is issued correctly.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Deprecated:

- ``HOOMDTrajectory.read_frame`` - use indexing to access frames from a trajectory.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
