### PR TITLE
Document that submodules are not imported by default.

### DIFF
--- a/doc/fl-examples.rst
+++ b/doc/fl-examples.rst
@@ -12,6 +12,13 @@ higher level access to **HOOMD** schema files, see :ref:`hoomd-examples`.
 
 View the page source to find unformatted example code.
 
+Import the module
+^^^^^^^^^^^^^^^^^
+
+.. ipython:: python
+
+    import gsd.fl
+
 Open a gsd file
 ^^^^^^^^^^^^^^^
 

--- a/doc/hoomd-examples.rst
+++ b/doc/hoomd-examples.rst
@@ -10,6 +10,13 @@ HOOMD examples
 
 View the page source to find unformatted example code.
 
+Import the module
+^^^^^^^^^^^^^^^^^
+
+.. ipython:: python
+
+    import gsd.hoomd
+
 Define a snapshot
 ^^^^^^^^^^^^^^^^^
 

--- a/gsd/__init__.py
+++ b/gsd/__init__.py
@@ -5,9 +5,10 @@
 
 The main package :py:mod:`gsd` is the root package. It holds the submodules
 :py:mod:`gsd.fl` and :py:mod:`gsd.hoomd`, but does not import them by default.
-You must explicitly modules before use::
+You must explicitly import these modules before use::
 
     import gsd.fl
+
     import gsd.hoomd
 
 Attributes:

--- a/gsd/__init__.py
+++ b/gsd/__init__.py
@@ -3,12 +3,12 @@
 
 """The GSD main module.
 
-The main package :py:mod:`gsd` is the root package. It holds submodules
-and does not import them. Users import the modules they need into their Python
-script::
+The main package :py:mod:`gsd` is the root package. It holds the submodules
+:py:mod:`gsd.fl` and :py:mod:`gsd.hoomd`, but does not import them by default.
+You must explicitly modules before use::
 
     import gsd.fl
-    f = gsd.fl.GSDFile('filename', 'rb');
+    import gsd.hoomd
 
 Attributes:
     __version__ (str): GSD software version number. This is the version number


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Base backwards compatible bug fixes on `trunk-patch`. -->
<!-- Base additional functionality on `trunk-minor`. -->
<!-- Base API incompatible changes on `trunk-major`. -->

## Description

<!-- Describe your changes in detail. -->
Document that submodules are not imported by default.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The GSD documentation did not clearly state that `gsd.hoomd` and `gsd.fl` required explicit imports.

## How Has This Been Tested?

I checked the sphinx docs rendered locally.

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Changed:

* Improved documentation
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
