### PR TITLE
setup.cfg: Replace dashes with underscores

### DIFF
--- a/doc/credits.rst
+++ b/doc/credits.rst
@@ -14,3 +14,4 @@ The following people contributed to GSD.
 * Vyas Ramasubramani, University of Michigan
 * Luis Y. Rivera-Rivera, University of Michigan
 * Brandon Butler, University of Michigan
+* Arthur Zamarin, Gentoo Linux

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[metadata]
-description-file = README.md
-
 [flake8]
 select = E,F,W,N,D,RST
 filename = *.pyx,*.px*,*.py


### PR DESCRIPTION
## Description

Remove `description-file` from `setup.cfg`

## Motivation and Context

Setuptools v54.1.0 introduces a warning that the use of dash-separated options in 'setup.cfg' will not be supported in a future version. https://github.com/pypa/setuptools/commit/a2e9ae4cb

> UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead

## How Has This Been Tested?

Package builds successfully in tree and in Gentoo's building facilities.

## Change log

```
Remove unused description-file from setup.cfg
```

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [X] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [X] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
