### PR TITLE
Build Python 3.10 wheels on Mac

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
 
       - name: Build wheels
-        uses: joerick/cibuildwheel@v2.1.3
+        uses: pypa/cibuildwheel@v2.2.2
 
       - uses: actions/upload-artifact@v2.2.4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     name: Build release tarball
     runs-on: ubuntu-latest
     container:
-      image: glotzerlab/ci:2021.08-ubuntu20.04
+      image: glotzerlab/ci:2021.11-ubuntu20.04
       options: -u 0
 
     steps:

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -24,7 +24,7 @@ jobs:
     name: Run clang-tidy
     runs-on: ubuntu-latest
     container:
-      image: glotzerlab/ci:2021.08-clang10_py38
+      image: glotzerlab/ci:2021.11-clang10_py38
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Configure

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -31,12 +31,12 @@ jobs:
     name: Unit test on Linux [${{ matrix.image }}]
     runs-on: ubuntu-latest
     container:
-      image: glotzerlab/ci:2021.08-${{ matrix.image }}
+      image: glotzerlab/ci:2021.11-${{ matrix.image }}
       options: -u 0
     strategy:
       matrix:
-        image: [clang12_py39,
-                gcc11_py39,
+        image: [clang12_py310,
+                gcc11_py310,
                 clang11_py39,
                 gcc10_py39,
                 gcc9_py38,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,13 @@ Change Log
 v2.x
 ----
 
+v2.5.1 (not yet released)
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Added*
+
+* Support for Python 3.10.
+
 v2.5.0 (2021-10-13)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ test-requires = "pytest"
 archs = ["auto64"]
 
 [tool.cibuildwheel.macos]
-skip = ["pp*"]
-
 # Build for x86_64 and arm64
 archs = ["x86_64", "arm64"]
+
+[tool.cibuildwheel.linux]
+# dependencies do not build for musl
+skip = ["pp* *musllinux*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,7 @@ test-requires = "pytest"
 archs = ["auto64"]
 
 [tool.cibuildwheel.macos]
-# MacOS wheels for numpy on cp310 are not available (as of 2021-10-08)
-skip = ["pp*", "cp310-*"]
+skip = ["pp*"]
 
 # Build for x86_64 and arm64
 archs = ["x86_64", "arm64"]


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Base backwards compatible bug fixes on `trunk-patch`. -->
<!-- Base additional functionality on `trunk-minor`. -->
<!-- Base API incompatible changes on `trunk-major`. -->

## Description

<!-- Describe your changes in detail. -->
Build Python 3.10 wheels on Mac.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Numpy wheels for Python 3.10 are now available. We can now provide users with Python 3.10 wheels.

## How Has This Been Tested?

The `build_wheel` CI workflow will test this.

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* Build Python 3.10 wheels for macosx.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
