### PR TITLE
Use new clang format

### DIFF
--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -32,20 +32,10 @@ jobs:
       - name: Execute clang-tidy
         run: clang-tidy -p=build gsd/*.c gsd/*.h scripts/*.cc --quiet --warnings-as-errors="*"
 
-  pre-commit:
-    name: Run pre-commit
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2.3.4
-    - uses: actions/setup-python@v2.2.2
-    - uses: pre-commit/action@v2.0.3
-      with:
-        extra_args: --all-files --hook-stage manual clang-format
-
   # This job is used to provide a single requirement for branch merge conditions.
   checks_complete:
     name: Style check
-    needs: [clang-tidy, pre-commit]
+    needs: [clang-tidy]
     runs-on: ubuntu-latest
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,8 +54,7 @@ repos:
     - pydocstyle==6.1.1
     - flake8-docstrings==1.6.0
     - flake8-rst-docstrings==0.2.3
-- repo: https://github.com/glotzerlab/pre-commit-clang-format
-  rev: v1.1.0
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v13.0.0
   hooks:
   - id: clang-format
-    stages: [manual]

--- a/doc/style.rst
+++ b/doc/style.rst
@@ -76,10 +76,6 @@ Tools
 
 * Autoformatter: `clang-format <https://clang.llvm.org/docs/ClangFormat.html>`_.
 
-  * Run: ``pre-commit run --all-files --hook-stage manual`` to apply changes to
-    the whole repository. You must have a ``conda`` installation in your
-    ``PATH`` to run this.
-
 * Linter: `clang-tidy <https://clang.llvm.org/extra/clang-tidy/>`_
 
   * Compile **GSD** with **CMake** to see **clang-tidy** output.


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Base backwards compatible bug fixes on `trunk-patch`. -->
<!-- Base additional functionality on `trunk-minor`. -->
<!-- Base API incompatible changes on `trunk-major`. -->

## Description

<!-- Describe your changes in detail. -->
Switch to the official pre-commit clang-format.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Remove the need for us to maintain our own hook and use pre-commit.ci with clang-format.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
The checks on this pull request validate the changes.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

Internal change, no log needed.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
