### PR TITLE
Raise an error when given duplicate types.

### DIFF
--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -248,6 +248,10 @@ class ParticleData(object):
             self.image = numpy.ascontiguousarray(self.image, dtype=numpy.int32)
             self.image = self.image.reshape([self.N, 3])
 
+        if (self.types is not None
+                and (not len(set(self.types)) == len(self.types))):
+            raise ValueError("Type names must be unique.")
+
 
 class BondData(object):
     """Store bond data chunks.
@@ -335,6 +339,10 @@ class BondData(object):
         if self.group is not None:
             self.group = numpy.ascontiguousarray(self.group, dtype=numpy.int32)
             self.group = self.group.reshape([self.N, self.M])
+
+        if (self.types is not None
+                and (not len(set(self.types)) == len(self.types))):
+            raise ValueError("Type names must be unique.")
 
 
 class ConstraintData(object):

--- a/gsd/test/test_hoomd.py
+++ b/gsd/test/test_hoomd.py
@@ -754,3 +754,18 @@ def test_pickle(tmp_path, open_mode):
         pkl = pickle.dumps(traj)
         with pickle.loads(pkl) as hf:
             assert len(hf) == 20
+
+
+@pytest.mark.parametrize(
+    'container',
+    ['particles', 'bonds', 'angles', 'dihedrals', 'impropers', 'pairs'])
+def test_no_duplicate_types(tmp_path, container):
+    """Test that duplicate types raise an error."""
+    with gsd.hoomd.open(name=tmp_path / "test_create.gsd", mode='wb') as hf:
+
+        snap = gsd.hoomd.Snapshot()
+
+        getattr(snap, container).types = ['A', 'B', 'B', 'C']
+
+        with pytest.raises(ValueError):
+            hf.append(snap)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Base backwards compatible bug fixes on `trunk-patch`. -->
<!-- Base additional functionality on `trunk-minor`. -->
<!-- Base API incompatible changes on `trunk-major`. -->

## Description

<!-- Describe your changes in detail. -->
Raise an error when given duplicate particle types.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The same as https://github.com/glotzerlab/hoomd-blue/pull/1377. Provide the same error when using gsd to write initial configurations.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #167

## How Has This Been Tested?

Added unit tests.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Changed:

* Raise an error when writing a frame with duplicate types.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
