### PR TITLE
Enable reading and writing in all write modes.

### DIFF
--- a/gsd/fl.pyx
+++ b/gsd/fl.pyx
@@ -173,15 +173,16 @@ def open(name, mode, application=None, schema=None, schema_version=None):
     | ``'rb+'``        | Open an existing file for reading and       |
     |                  | writing.                                    |
     +------------------+---------------------------------------------+
-    | ``'wb'``         | Open a file for writing. Creates the file   |
-    |                  | if needed, or overwrites an existing file.  |
+    | ``'wb'``         | Open a file for reading and writing.        |
+    |                  | Creates the file if needed, or overwrites   |
+    |                  | an existing file.                           |
     +------------------+---------------------------------------------+
     | ``'wb+'``        | Open a file for reading and writing.        |
     |                  | Creates the file if needed, or overwrites   |
     |                  | an existing file.                           |
     +------------------+---------------------------------------------+
     | ``'xb'``         | Create a gsd file exclusively and opens it  |
-    |                  | for writing.                                |
+    |                  | for reading and writing.                    |
     |                  | Raise :py:exc:`FileExistsError`             |
     |                  | if it already exists.                       |
     +------------------+---------------------------------------------+
@@ -190,9 +191,9 @@ def open(name, mode, application=None, schema=None, schema_version=None):
     |                  | Raise :py:exc:`FileExistsError`             |
     |                  | if it already exists.                       |
     +------------------+---------------------------------------------+
-    | ``'ab'``         | Open an existing file for writing.          |
-    |                  | Does *not* create or overwrite existing     |
-    |                  | files.                                      |
+    | ``'ab'``         | Open an existing file for reading and       |
+    |                  | writing. Does *not* create or overwrite     |
+    |                  | existing files.                             |
     +------------------+---------------------------------------------+
 
     When opening a file for reading (``'r'`` and ``'a'`` modes): ``application``

--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -2077,10 +2077,6 @@ gsd_find_chunk(struct gsd_handle* handle, uint64_t frame, const char* name)
         {
         return NULL;
         }
-    if (handle->open_flags == GSD_OPEN_APPEND)
-        {
-        return NULL;
-        }
 
     // find the id for the given name
     uint16_t match_id = gsd_name_id_map_find(&handle->name_map, name);
@@ -2170,10 +2166,6 @@ int gsd_read_chunk(struct gsd_handle* handle, void* data, const struct gsd_index
     if (chunk == NULL)
         {
         return GSD_ERROR_INVALID_ARGUMENT;
-        }
-    if (handle->open_flags == GSD_OPEN_APPEND)
-        {
-        return GSD_ERROR_FILE_MUST_BE_READABLE;
         }
 
     size_t size = chunk->N * chunk->M * gsd_sizeof_type((enum gsd_type)chunk->type);

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -1056,15 +1056,16 @@ def open(name, mode='rb'):
     | ``'rb+'``        | Open an existing file for reading and       |
     |                  | writing.                                    |
     +------------------+---------------------------------------------+
-    | ``'wb'``         | Open a file for writing. Creates the file   |
-    |                  | if needed, or overwrites an existing file.  |
+    | ``'wb'``         | Open a file for reading and writing.        |
+    |                  | Creates the file if needed, or overwrites   |
+    |                  | an existing file.                           |
     +------------------+---------------------------------------------+
     | ``'wb+'``        | Open a file for reading and writing.        |
     |                  | Creates the file if needed, or overwrites   |
     |                  | an existing file.                           |
     +------------------+---------------------------------------------+
     | ``'xb'``         | Create a gsd file exclusively and opens it  |
-    |                  | for writing.                                |
+    |                  | for reading and writing.                    |
     |                  | Raise :py:exc:`FileExistsError`             |
     |                  | if it already exists.                       |
     +------------------+---------------------------------------------+
@@ -1073,11 +1074,10 @@ def open(name, mode='rb'):
     |                  | Raise :py:exc:`FileExistsError`             |
     |                  | if it already exists.                       |
     +------------------+---------------------------------------------+
-    | ``'ab'``         | Open an existing file for writing.          |
-    |                  | Does *not* create or overwrite existing     |
-    |                  | files.                                      |
+    | ``'ab'``         | Open an existing file for reading and       |
+    |                  | writing. Does *not* create or overwrite     |
+    |                  | existing files.                             |
     +------------------+---------------------------------------------+
-
     """
     if fl is None:
         raise RuntimeError("file layer module is not available")

--- a/gsd/test/test_fl.py
+++ b/gsd/test/test_fl.py
@@ -934,10 +934,10 @@ def test_read_write(tmp_path, mode):
     """Test that data chunks can read from files opened in all write modes."""
     if mode[0] == 'r' or mode[0] == 'a':
         with gsd.fl.open(name=tmp_path / 'test_read_write.gsd',
-                        mode='wb',
-                        application='test_read_write',
-                        schema='none',
-                        schema_version=[1, 2]):
+                         mode='wb',
+                         application='test_read_write',
+                         schema='none',
+                         schema_version=[1, 2]):
             pass
 
     data = numpy.array([10], dtype=numpy.int64)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Base backwards compatible bug fixes on `trunk-patch`. -->
<!-- Base additional functionality on `trunk-minor`. -->
<!-- Base API incompatible changes on `trunk-major`. -->

## Description

<!-- Describe your changes in detail. -->
Allow all write modes (those not `'rb'`) to both read and write GSD files.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This was intended to be enabled with the v2.0 release, but it was not.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Added unit tests.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Data chunks can now be read from files opened in 'wb', 'xb', and 'ab' modes.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
