### PR TITLE
Rename `Snapshot` to `Frame`.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
     ],
     "[restructuredtext]": {
         "editor.rulers": [
-            80
+            100
         ]
     },
     "[python]": {
@@ -23,7 +23,7 @@
     },
     "[markdown]": {
         "editor.rulers": [
-            80
+            100
         ]
     },
     "python.linting.flake8Enabled": true,

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ API to specify the initial condition for a **HOOMD-blue** simulation or analyze 
 
 Create a hoomd gsd file.
 ```python
->>> s = gsd.hoomd.Snapshot()
+>>> s = gsd.hoomd.Frame()
 >>> s.particles.N = 4
 >>> s.particles.types = ['A', 'B']
 >>> s.particles.typeid = [0,0,1,1]
@@ -35,7 +35,7 @@ Create a hoomd gsd file.
 Append frames to a gsd file:
 ```python
 >>> def create_frame(i):
-...     s = gsd.hoomd.Snapshot();
+...     s = gsd.hoomd.Frame();
 ...     s.configuration.step = i;
 ...     s.particles.N = 4+i;
 ...     s.particles.position = numpy.random.random(size=(4+i,3))
@@ -49,12 +49,12 @@ Append frames to a gsd file:
 Randomly index frames:
 ```python
 >>> with gsd.hoomd.open('test.gsd', 'rb') as t:
-...     snap = t[5]
-...     print(snap.configuration.step)
+...     frame = t[5]
+...     print(frame.configuration.step)
 4
-...     print(snap.particles.N)
+...     print(frame.particles.N)
 8
-...     print(snap.particles.position)
+...     print(frame.particles.position)
 [[ 0.56993282  0.42243481  0.5502916 ]
  [ 0.36892486  0.38167036  0.27310368]
  [ 0.04739023  0.13603486  0.196539  ]

--- a/doc/python-module-gsd.hoomd.rst
+++ b/doc/python-module-gsd.hoomd.rst
@@ -7,3 +7,4 @@ gsd.hoomd module
 .. automodule:: gsd.hoomd
     :synopsis: Reference implementation for reading/writing hoomd schema GSD files.
     :members:
+    :show-inheritance:

--- a/doc/schema-hoomd.rst
+++ b/doc/schema-hoomd.rst
@@ -38,7 +38,7 @@ Data chunks
 -----------
 
 Each frame the ``hoomd`` schema may contain one or more data chunks. The layout
-and names of the chunksmatch that of the binary snapshot API in HOOMD-blue
+and names of the chunksmatch that of the binary frame API in HOOMD-blue
 itself. Data chunks are organized in categories. These categories have no
 meaning in the ``hoomd`` schema specification, and are simply an organizational
 tool. Some file writers may implement options that act on categories (i.e. write
@@ -132,7 +132,7 @@ Configuration
     Number of dimensions in the simulation. Must be 2 or 3.
 
     .. note::
-        When using `gsd.hoomd.Snapshot`, the object will try to intelligently default to a
+        When using `gsd.hoomd.Frame`, the object will try to intelligently default to a
         dimension. When setting a box with :math:`L_z = 0`, ``dimensions`` will default to
         2 otherwise 3. Explicit setting of this value by users always takes precedence.
 

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -408,7 +408,7 @@ class ConstraintData(object):
 
 
 class Frame(object):
-    """Frame of a system state.
+    """System state at one point in time.
 
     Attributes:
         configuration (`ConfigurationData`): Configuration data.
@@ -632,6 +632,19 @@ class Frame(object):
                 raise RuntimeError('Not a valid state: ' + k)
 
 
+class Snapshot(Frame):
+    """System state at one point in time.
+
+    .. deprecated:: 2.8.0
+
+        Replaced by `Frame`.
+    """
+
+    def __init__(self):
+        warnings.warn("Snapshot is deprecated, use Frame", FutureWarning)
+        super().__init__()
+
+
 class _HOOMDTrajectoryIterable(object):
     """Iterable over a HOOMDTrajectory object."""
 
@@ -729,8 +742,7 @@ class HOOMDTrajectory(object):
         frame. If it is the same, do not write it out as it can be instantiated
         either from the value at the initial frame or the default value.
         """
-        logger.debug('Appending frame to hoomd trajectory: '
-                     + str(self.file))
+        logger.debug('Appending frame to hoomd trajectory: ' + str(self.file))
 
         frame.validate()
 
@@ -874,7 +886,8 @@ class HOOMDTrajectory(object):
             frame.configuration.step = step_arr[0]
         else:
             if self._initial_frame is not None:
-                frame.configuration.step = self._initial_frame.configuration.step
+                frame.configuration.step = \
+                    self._initial_frame.configuration.step
             else:
                 frame.configuration.step = \
                     frame.configuration._default_value['step']
@@ -985,7 +998,7 @@ class HOOMDTrajectory(object):
         for state in frame._valid_state:
             if self.file.chunk_exists(frame=idx, name='state/' + state):
                 frame.state[state] = self.file.read_chunk(frame=idx,
-                                                         name='state/' + state)
+                                                          name='state/' + state)
 
         # read log data
         logged_data_names = self.file.find_matching_chunk_names('log/')

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -6,11 +6,11 @@
 :py:mod:`gsd.hoomd` reads and writes GSD files with the ``hoomd`` schema.
 
 * `HOOMDTrajectory` - Read and write hoomd schema GSD files.
-* `Snapshot` - Store the state of a single frame.
+* `Frame` - Store the state of a single frame.
 
-  * `ConfigurationData` - Store configuration data in a snapshot.
-  * `ParticleData` - Store particle data in a snapshot.
-  * `BondData` - Store topology data in a snapshot.
+  * `ConfigurationData` - Store configuration data in a frame.
+  * `ParticleData` - Store particle data in a frame.
+  * `BondData` - Store topology data in a frame.
 
 * `open` - Open a hoomd schema GSD file.
 * `read_log` - Read log from a hoomd schema GSD file into a dict of time-series
@@ -42,7 +42,7 @@ logger = logging.getLogger('gsd.hoomd')
 class ConfigurationData(object):
     """Store configuration data.
 
-    Use the `Snapshot.configuration` attribute of a to access the configuration.
+    Use the `Frame.configuration` attribute of a to access the configuration.
 
     Attributes:
         step (int): Time step of this frame (:chunk:`configuration/step`).
@@ -108,18 +108,18 @@ class ConfigurationData(object):
 class ParticleData(object):
     """Store particle data chunks.
 
-    Use the `Snapshot.particles` attribute of a to access the particles.
+    Use the `Frame.particles` attribute of a to access the particles.
 
     Instances resulting from file read operations will always store array
     quantities in `numpy.ndarray` objects of the defined types. User created
-    snapshots may provide input data that can be converted to a `numpy.ndarray`.
+    frames may provide input data that can be converted to a `numpy.ndarray`.
 
     See Also:
         `hoomd.State` for a full description of how HOOMD interprets this
         data.
 
     Attributes:
-        N (int): Number of particles in the snapshot (:chunk:`particles/N`).
+        N (int): Number of particles in the frame (:chunk:`particles/N`).
 
         types (tuple[str]):
             Names of the particle types (:chunk:`particles/types`).
@@ -259,13 +259,13 @@ class ParticleData(object):
 class BondData(object):
     """Store bond data chunks.
 
-    Use the `Snapshot.bonds`, `Snapshot.angles`, `Snapshot.dihedrals`,
-    `Snapshot.impropers`, and `Snapshot.pairs` attributes to access the bond
+    Use the `Frame.bonds`, `Frame.angles`, `Frame.dihedrals`,
+    `Frame.impropers`, and `Frame.pairs` attributes to access the bond
     topology.
 
     Instances resulting from file read operations will always store array
     quantities in `numpy.ndarray` objects of the defined types. User created
-    snapshots may provide input data that can be converted to a `numpy.ndarray`.
+    frames may provide input data that can be converted to a `numpy.ndarray`.
 
     See Also:
         `hoomd.State` for a full description of how HOOMD interprets this
@@ -288,7 +288,7 @@ class BondData(object):
 
     Attributes:
         N (int): Number of bonds/angles/dihedrals/impropers/pairs in the
-          snapshot
+          frame
           (:chunk:`bonds/N`, :chunk:`angles/N`, :chunk:`dihedrals/N`,
           :chunk:`impropers/N`, :chunk:`pairs/N`).
 
@@ -351,18 +351,18 @@ class BondData(object):
 class ConstraintData(object):
     """Store constraint data.
 
-    Use the `Snapshot.constraints` attribute to access the constraints.
+    Use the `Frame.constraints` attribute to access the constraints.
 
     Instances resulting from file read operations will always store array
     quantities in `numpy.ndarray` objects of the defined types. User created
-    snapshots may provide input data that can be converted to a `numpy.ndarray`.
+    frames may provide input data that can be converted to a `numpy.ndarray`.
 
     See Also:
         `hoomd.State` for a full description of how HOOMD interprets this
         data.
 
     Attributes:
-        N (int): Number of constraints in the snapshot (:chunk:`constraints/N`).
+        N (int): Number of constraints in the frame (:chunk:`constraints/N`).
 
         value ((*N*, ) `numpy.ndarray` of ``numpy.float32``):
             Constraint length (:chunk:`constraints/value`).
@@ -407,8 +407,8 @@ class ConstraintData(object):
             self.group = self.group.reshape([self.N, self.M])
 
 
-class Snapshot(object):
-    """Snapshot of a system state.
+class Frame(object):
+    """Frame of a system state.
 
     Attributes:
         configuration (`ConfigurationData`): Configuration data.
@@ -468,8 +468,8 @@ class Snapshot(object):
         ]
 
     def validate(self):
-        """Validate all contained snapshot data."""
-        logger.debug('Validating Snapshot')
+        """Validate all contained frame data."""
+        logger.debug('Validating Frame')
 
         self.configuration.validate()
         self.particles.validate()
@@ -716,23 +716,23 @@ class HOOMDTrajectory(object):
         """The number of frames in the trajectory."""
         return self.file.nframes
 
-    def append(self, snapshot):
-        """Append a snapshot to a hoomd gsd file.
+    def append(self, frame):
+        """Append a frame to a hoomd gsd file.
 
         Args:
-            snapshot (:py:class:`Snapshot`): Snapshot to append.
+            frame (:py:class:`Frame`): Frame to append.
 
-        Write the given snapshot to the file at the current frame and increase
+        Write the given frame to the file at the current frame and increase
         the frame counter. Do not write any fields that are ``None``. For all
         non-``None`` fields, scan them and see if they match the initial frame
         or the default value. If the given data differs, write it out to the
         frame. If it is the same, do not write it out as it can be instantiated
         either from the value at the initial frame or the default value.
         """
-        logger.debug('Appending snapshot to hoomd trajectory: '
+        logger.debug('Appending frame to hoomd trajectory: '
                      + str(self.file))
 
-        snapshot.validate()
+        frame.validate()
 
         # want the initial frame specified as a reference to detect if chunks
         # need to be written
@@ -749,9 +749,9 @@ class HOOMDTrajectory(object):
                 'constraints',
                 'pairs',
         ]:
-            container = getattr(snapshot, path)
+            container = getattr(frame, path)
             for name in container._default_value:
-                if self._should_write(path, name, snapshot):
+                if self._should_write(path, name, frame):
                     logger.debug('writing data chunk: ' + path + '/' + name)
                     data = getattr(container, name)
 
@@ -773,11 +773,11 @@ class HOOMDTrajectory(object):
                     self.file.write_chunk(path + '/' + name, data)
 
         # write state data
-        for state, data in snapshot.state.items():
+        for state, data in frame.state.items():
             self.file.write_chunk('state/' + state, data)
 
         # write log data
-        for log, data in snapshot.log.items():
+        for log, data in frame.log.items():
             self.file.write_chunk('log/' + log, data)
 
         self.file.end_frame()
@@ -792,19 +792,19 @@ class HOOMDTrajectory(object):
         self.file.close()
         del self._initial_frame
 
-    def _should_write(self, path, name, snapshot):
+    def _should_write(self, path, name, frame):
         """Test if we should write a given data chunk.
 
         Args:
             path (str): Path part of the data chunk.
             name (str): Name part of the data chunk.
-            snapshot (:py:class:`Snapshot`): Snapshot data is from.
+            frame (:py:class:`Frame`): Frame data is from.
 
         Returns:
             False if the data matches that in the initial frame. False
             if the data matches all default values. True otherwise.
         """
-        container = getattr(snapshot, path)
+        container = getattr(frame, path)
         data = getattr(container, name)
 
         if data is None:
@@ -830,9 +830,9 @@ class HOOMDTrajectory(object):
         """Append each item of the iterable to the file.
 
         Args:
-            iterable: An iterable object the provides :py:class:`Snapshot`
+            iterable: An iterable object the provides :py:class:`Frame`
                 instances. This could be another HOOMDTrajectory, a generator
-                that modifies snapshots, or a list of snapshots.
+                that modifies frames, or a list of frames.
         """
         for item in iterable:
             self.append(item)
@@ -844,7 +844,7 @@ class HOOMDTrajectory(object):
             idx (int): Frame index to read.
 
         Returns:
-            `Snapshot` with the frame data
+            `Frame` with the frame data
 
         Replace any data chunks not present in the given frame with either data
         from frame 0, or initialize from default values if not in frame 0. Cache
@@ -866,40 +866,40 @@ class HOOMDTrajectory(object):
         if self._initial_frame is None and idx != 0:
             self._read_frame(0)
 
-        snap = Snapshot()
+        frame = Frame()
         # read configuration first
         if self.file.chunk_exists(frame=idx, name='configuration/step'):
             step_arr = self.file.read_chunk(frame=idx,
                                             name='configuration/step')
-            snap.configuration.step = step_arr[0]
+            frame.configuration.step = step_arr[0]
         else:
             if self._initial_frame is not None:
-                snap.configuration.step = self._initial_frame.configuration.step
+                frame.configuration.step = self._initial_frame.configuration.step
             else:
-                snap.configuration.step = \
-                    snap.configuration._default_value['step']
+                frame.configuration.step = \
+                    frame.configuration._default_value['step']
 
         if self.file.chunk_exists(frame=idx, name='configuration/dimensions'):
             dimensions_arr = self.file.read_chunk(
                 frame=idx, name='configuration/dimensions')
-            snap.configuration.dimensions = dimensions_arr[0]
+            frame.configuration.dimensions = dimensions_arr[0]
         else:
             if self._initial_frame is not None:
-                snap.configuration.dimensions = \
+                frame.configuration.dimensions = \
                     self._initial_frame.configuration.dimensions
             else:
-                snap.configuration.dimensions = \
-                    snap.configuration._default_value['dimensions']
+                frame.configuration.dimensions = \
+                    frame.configuration._default_value['dimensions']
 
         if self.file.chunk_exists(frame=idx, name='configuration/box'):
-            snap.configuration.box = self.file.read_chunk(
+            frame.configuration.box = self.file.read_chunk(
                 frame=idx, name='configuration/box')
         else:
             if self._initial_frame is not None:
-                snap.configuration.box = self._initial_frame.configuration.box
+                frame.configuration.box = self._initial_frame.configuration.box
             else:
-                snap.configuration.box = \
-                    snap.configuration._default_value['box']
+                frame.configuration.box = \
+                    frame.configuration._default_value['box']
 
         # then read all groups that have N, types, etc...
         for path in [
@@ -911,7 +911,7 @@ class HOOMDTrajectory(object):
                 'constraints',
                 'pairs',
         ]:
-            container = getattr(snap, path)
+            container = getattr(frame, path)
             if self._initial_frame is not None:
                 initial_frame_container = getattr(self._initial_frame, path)
 
@@ -982,25 +982,25 @@ class HOOMDTrajectory(object):
                     container.__dict__[name].flags.writeable = False
 
         # read state data
-        for state in snap._valid_state:
+        for state in frame._valid_state:
             if self.file.chunk_exists(frame=idx, name='state/' + state):
-                snap.state[state] = self.file.read_chunk(frame=idx,
+                frame.state[state] = self.file.read_chunk(frame=idx,
                                                          name='state/' + state)
 
         # read log data
         logged_data_names = self.file.find_matching_chunk_names('log/')
         for log in logged_data_names:
             if self.file.chunk_exists(frame=idx, name=log):
-                snap.log[log[4:]] = self.file.read_chunk(frame=idx, name=log)
+                frame.log[log[4:]] = self.file.read_chunk(frame=idx, name=log)
             else:
                 if self._initial_frame is not None:
-                    snap.log[log[4:]] = self._initial_frame.log[log[4:]]
+                    frame.log[log[4:]] = self._initial_frame.log[log[4:]]
 
         # store initial frame
         if self._initial_frame is None and idx == 0:
-            self._initial_frame = snap
+            self._initial_frame = frame
 
-        return snap
+        return frame
 
     def __getitem__(self, key):
         """Index trajectory frames.
@@ -1109,7 +1109,7 @@ def read_log(name, scalar_only=False):
 
     Caution:
         `read_log` requires that a logged quantity has the same shape in all
-        frames. Use `open` and `Snapshot.log` to read files where the shape
+        frames. Use `open` and `Frame.log` to read files where the shape
         changes from frame to frame.
 
     To create a *pandas* ``DataFrame`` with the logged data:

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -874,7 +874,7 @@ class HOOMDTrajectory(object):
 
         .. deprecated:: v2.5
         """
-        warnings.warn("Deprecated, trajectory[idx]", DeprecationWarning)
+        warnings.warn("Deprecated, trajectory[idx]", FutureWarning)
         return self._read_frame(idx)
 
     def _read_frame(self, idx):

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -407,33 +407,17 @@ class ConstraintData(object):
             self.group = self.group.reshape([self.N, self.M])
 
 
-class Frame(object):
+class Snapshot(object):
     """System state at one point in time.
 
-    Attributes:
-        configuration (`ConfigurationData`): Configuration data.
+    .. deprecated:: 2.8.0
 
-        particles (`ParticleData`): Particles.
-
-        bonds (`BondData`): Bonds.
-
-        angles (`BondData`): Angles.
-
-        dihedrals (`BondData`): Dihedrals.
-
-        impropers (`BondData`): Impropers.
-
-        pairs (`BondData`): Special pair.
-
-        constraints (`ConstraintData`): Distance constraints.
-
-        state (dict): State data.
-
-        log (dict): Logged data (values must be `numpy.ndarray` or
-            `array_like`)
+        Replaced by `Frame`.
     """
-
     def __init__(self):
+        if not isinstance(self, Frame):
+            warnings.warn("Snapshot is deprecated, use Frame", FutureWarning)
+
         self.configuration = ConfigurationData()
         self.particles = ParticleData()
         self.bonds = BondData(2)
@@ -632,16 +616,33 @@ class Frame(object):
                 raise RuntimeError('Not a valid state: ' + k)
 
 
-class Snapshot(Frame):
+class Frame(Snapshot):
     """System state at one point in time.
 
-    .. deprecated:: 2.8.0
+    Attributes:
+        configuration (`ConfigurationData`): Configuration data.
 
-        Replaced by `Frame`.
+        particles (`ParticleData`): Particles.
+
+        bonds (`BondData`): Bonds.
+
+        angles (`BondData`): Angles.
+
+        dihedrals (`BondData`): Dihedrals.
+
+        impropers (`BondData`): Impropers.
+
+        pairs (`BondData`): Special pair.
+
+        constraints (`ConstraintData`): Distance constraints.
+
+        state (dict): State data.
+
+        log (dict): Logged data (values must be `numpy.ndarray` or
+            `array_like`)
     """
 
     def __init__(self):
-        warnings.warn("Snapshot is deprecated, use Frame", FutureWarning)
         super().__init__()
 
 

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -414,6 +414,7 @@ class Snapshot(object):
 
         Replaced by `Frame`.
     """
+
     def __init__(self):
         if not isinstance(self, Frame):
             warnings.warn("Snapshot is deprecated, use Frame", FutureWarning)
@@ -831,7 +832,14 @@ class HOOMDTrajectory(object):
                              + '/' + name)
                 return False
 
-        if numpy.array_equiv(data, container._default_value[name]) \
+        matches_default_value = False
+        if name == 'types':
+            matches_default_value = data == container._default_value[name]
+        else:
+            matches_default_value = numpy.array_equiv(
+                data, container._default_value[name])
+
+        if matches_default_value \
                 and not self.file.chunk_exists(frame=0, name=path + '/' + name):
             logger.debug('skipping data chunk, default value: ' + path + '/'
                          + name)

--- a/gsd/test/test_fl.py
+++ b/gsd/test/test_fl.py
@@ -40,7 +40,7 @@ def test_create(tmp_path):
 ])
 def test_dtype(tmp_path, typ):
     """Test all supported data types."""
-    data1d = numpy.array([1, 2, 3, 4, 5, 10012], dtype=typ)
+    data1d = numpy.array([1, 2, 3, 4, 5, 127], dtype=typ)
     data2d = numpy.array([[10, 20], [30, 40], [50, 80]], dtype=typ)
     data_zero = numpy.array([], dtype=typ)
 

--- a/gsd/test/test_hoomd.py
+++ b/gsd/test/test_hoomd.py
@@ -244,12 +244,14 @@ def assert_frames_equal(s, frame0, check_position=True, check_step=True):
     assert s.particles.N == frame0.particles.N
     assert s.particles.types == frame0.particles.types
     assert s.particles.type_shapes == frame0.particles.type_shapes
-    numpy.testing.assert_array_equal(s.particles.typeid, frame0.particles.typeid)
+    numpy.testing.assert_array_equal(s.particles.typeid,
+                                     frame0.particles.typeid)
     numpy.testing.assert_array_equal(s.particles.mass, frame0.particles.mass)
     numpy.testing.assert_array_equal(s.particles.diameter,
                                      frame0.particles.diameter)
     numpy.testing.assert_array_equal(s.particles.body, frame0.particles.body)
-    numpy.testing.assert_array_equal(s.particles.charge, frame0.particles.charge)
+    numpy.testing.assert_array_equal(s.particles.charge,
+                                     frame0.particles.charge)
     numpy.testing.assert_array_equal(s.particles.moment_inertia,
                                      frame0.particles.moment_inertia)
     if check_position:
@@ -259,7 +261,8 @@ def assert_frames_equal(s, frame0, check_position=True, check_step=True):
                                      frame0.particles.orientation)
     numpy.testing.assert_array_equal(s.particles.velocity,
                                      frame0.particles.velocity)
-    numpy.testing.assert_array_equal(s.particles.angmom, frame0.particles.angmom)
+    numpy.testing.assert_array_equal(s.particles.angmom,
+                                     frame0.particles.angmom)
     numpy.testing.assert_array_equal(s.particles.image, frame0.particles.image)
 
     assert s.bonds.N == frame0.bonds.N
@@ -274,12 +277,14 @@ def assert_frames_equal(s, frame0, check_position=True, check_step=True):
 
     assert s.dihedrals.N == frame0.dihedrals.N
     assert s.dihedrals.types == frame0.dihedrals.types
-    numpy.testing.assert_array_equal(s.dihedrals.typeid, frame0.dihedrals.typeid)
+    numpy.testing.assert_array_equal(s.dihedrals.typeid,
+                                     frame0.dihedrals.typeid)
     numpy.testing.assert_array_equal(s.dihedrals.group, frame0.dihedrals.group)
 
     assert s.impropers.N == frame0.impropers.N
     assert s.impropers.types == frame0.impropers.types
-    numpy.testing.assert_array_equal(s.impropers.typeid, frame0.impropers.typeid)
+    numpy.testing.assert_array_equal(s.impropers.typeid,
+                                     frame0.impropers.typeid)
     numpy.testing.assert_array_equal(s.impropers.group, frame0.impropers.group)
 
     assert s.constraints.N == frame0.constraints.N
@@ -688,7 +693,7 @@ def test_state(tmp_path, open_mode):
 
     frame1.state['hpmc/convex_polyhedron/N'] = [3]
     frame1.state['hpmc/convex_polyhedron/vertices'] = [[-1, -1, -1], [0, 1, 1],
-                                                      [1, 0, 0]]
+                                                       [1, 0, 0]]
 
     with gsd.hoomd.open(name=tmp_path / "test_state.gsd",
                         mode=open_mode.write) as hf:

--- a/gsd/test/test_hoomd.py
+++ b/gsd/test/test_hoomd.py
@@ -19,14 +19,14 @@ def test_create(tmp_path):
 
 def test_append(tmp_path, open_mode):
     """Test that gsd files can be appended to."""
-    snap = gsd.hoomd.Snapshot()
-    snap.particles.N = 10
+    frame = gsd.hoomd.Frame()
+    frame.particles.N = 10
 
     with gsd.hoomd.open(name=tmp_path / "test_append.gsd",
                         mode=open_mode.write) as hf:
         for i in range(5):
-            snap.configuration.step = i + 1
-            hf.append(snap)
+            frame.configuration.step = i + 1
+            hf.append(frame)
 
     with gsd.hoomd.open(name=tmp_path / "test_append.gsd",
                         mode=open_mode.read) as hf:
@@ -34,16 +34,16 @@ def test_append(tmp_path, open_mode):
 
 
 def create_frame(i):
-    """Helper function to create snapshot objects."""
-    snap = gsd.hoomd.Snapshot()
-    snap.configuration.step = i + 1
-    return snap
+    """Helper function to create frame objects."""
+    frame = gsd.hoomd.Frame()
+    frame.configuration.step = i + 1
+    return frame
 
 
 def test_extend(tmp_path, open_mode):
     """Test that the extend method works."""
-    snap = gsd.hoomd.Snapshot()
-    snap.particles.N = 10
+    frame = gsd.hoomd.Frame()
+    frame.particles.N = 10
 
     with gsd.hoomd.open(name=tmp_path / "test_extend.gsd",
                         mode=open_mode.write) as hf:
@@ -56,18 +56,18 @@ def test_extend(tmp_path, open_mode):
 
 def test_defaults(tmp_path, open_mode):
     """Test that the property defaults are properly set."""
-    snap = gsd.hoomd.Snapshot()
-    snap.particles.N = 2
-    snap.bonds.N = 3
-    snap.angles.N = 4
-    snap.dihedrals.N = 5
-    snap.impropers.N = 6
-    snap.constraints.N = 4
-    snap.pairs.N = 7
+    frame = gsd.hoomd.Frame()
+    frame.particles.N = 2
+    frame.bonds.N = 3
+    frame.angles.N = 4
+    frame.dihedrals.N = 5
+    frame.impropers.N = 6
+    frame.constraints.N = 4
+    frame.pairs.N = 7
 
     with gsd.hoomd.open(name=tmp_path / "test_defaults.gsd",
                         mode=open_mode.write) as hf:
-        hf.append(snap)
+        hf.append(frame)
 
     with gsd.hoomd.open(name=tmp_path / "test_defaults.gsd",
                         mode=open_mode.read) as hf:
@@ -166,15 +166,15 @@ def test_defaults(tmp_path, open_mode):
         assert len(s.state) == 0
 
 
-def make_nondefault_snapshot():
-    """Make a snapshot with all non-default values."""
-    snap0 = gsd.hoomd.Snapshot()
-    snap0.configuration.step = 10000
-    snap0.configuration.dimensions = 2
-    snap0.configuration.box = [4, 5, 6, 1.0, 0.5, 0.25]
-    snap0.particles.N = 2
-    snap0.particles.types = ['A', 'B', 'C']
-    snap0.particles.type_shapes = [
+def make_nondefault_frame():
+    """Make a frame with all non-default values."""
+    frame0 = gsd.hoomd.Frame()
+    frame0.configuration.step = 10000
+    frame0.configuration.dimensions = 2
+    frame0.configuration.box = [4, 5, 6, 1.0, 0.5, 0.25]
+    frame0.particles.N = 2
+    frame0.particles.types = ['A', 'B', 'C']
+    frame0.particles.type_shapes = [
         {
             "type": "Sphere",
             "diameter": 2.0
@@ -188,157 +188,157 @@ def make_nondefault_snapshot():
             "diameter": 4.0
         },
     ]
-    snap0.particles.typeid = [1, 2]
-    snap0.particles.mass = [2, 3]
-    snap0.particles.diameter = [3, 4]
-    snap0.particles.body = [10, 20]
-    snap0.particles.charge = [0.5, 0.25]
-    snap0.particles.moment_inertia = [[1, 2, 3], [3, 2, 1]]
-    snap0.particles.position = [[0.1, 0.2, 0.3], [-1.0, -2.0, -3.0]]
-    snap0.particles.orientation = [[1, 0.1, 0.2, 0.3], [0, -1.0, -2.0, -3.0]]
-    snap0.particles.velocity = [[1.1, 2.2, 3.3], [-3.3, -2.2, -1.1]]
-    snap0.particles.angmom = [[1, 1.1, 2.2, 3.3], [-1, -3.3, -2.2, -1.1]]
-    snap0.particles.image = [[10, 20, 30], [5, 6, 7]]
+    frame0.particles.typeid = [1, 2]
+    frame0.particles.mass = [2, 3]
+    frame0.particles.diameter = [3, 4]
+    frame0.particles.body = [10, 20]
+    frame0.particles.charge = [0.5, 0.25]
+    frame0.particles.moment_inertia = [[1, 2, 3], [3, 2, 1]]
+    frame0.particles.position = [[0.1, 0.2, 0.3], [-1.0, -2.0, -3.0]]
+    frame0.particles.orientation = [[1, 0.1, 0.2, 0.3], [0, -1.0, -2.0, -3.0]]
+    frame0.particles.velocity = [[1.1, 2.2, 3.3], [-3.3, -2.2, -1.1]]
+    frame0.particles.angmom = [[1, 1.1, 2.2, 3.3], [-1, -3.3, -2.2, -1.1]]
+    frame0.particles.image = [[10, 20, 30], [5, 6, 7]]
 
-    snap0.bonds.N = 1
-    snap0.bonds.types = ['bondA', 'bondB']
-    snap0.bonds.typeid = [1]
-    snap0.bonds.group = [[0, 1]]
+    frame0.bonds.N = 1
+    frame0.bonds.types = ['bondA', 'bondB']
+    frame0.bonds.typeid = [1]
+    frame0.bonds.group = [[0, 1]]
 
-    snap0.angles.N = 1
-    snap0.angles.typeid = [2]
-    snap0.angles.types = ['angleA', 'angleB']
-    snap0.angles.group = [[0, 1, 0]]
+    frame0.angles.N = 1
+    frame0.angles.typeid = [2]
+    frame0.angles.types = ['angleA', 'angleB']
+    frame0.angles.group = [[0, 1, 0]]
 
-    snap0.dihedrals.N = 1
-    snap0.dihedrals.typeid = [3]
-    snap0.dihedrals.types = ['dihedralA', 'dihedralB']
-    snap0.dihedrals.group = [[0, 1, 1, 0]]
+    frame0.dihedrals.N = 1
+    frame0.dihedrals.typeid = [3]
+    frame0.dihedrals.types = ['dihedralA', 'dihedralB']
+    frame0.dihedrals.group = [[0, 1, 1, 0]]
 
-    snap0.impropers.N = 1
-    snap0.impropers.typeid = [4]
-    snap0.impropers.types = ['improperA', 'improperB']
-    snap0.impropers.group = [[1, 0, 0, 1]]
+    frame0.impropers.N = 1
+    frame0.impropers.typeid = [4]
+    frame0.impropers.types = ['improperA', 'improperB']
+    frame0.impropers.group = [[1, 0, 0, 1]]
 
-    snap0.constraints.N = 1
-    snap0.constraints.value = [1.1]
-    snap0.constraints.group = [[0, 1]]
+    frame0.constraints.N = 1
+    frame0.constraints.value = [1.1]
+    frame0.constraints.group = [[0, 1]]
 
-    snap0.pairs.N = 1
-    snap0.pairs.types = ['pairA', 'pairB']
-    snap0.pairs.typeid = [1]
-    snap0.pairs.group = [[0, 3]]
+    frame0.pairs.N = 1
+    frame0.pairs.types = ['pairA', 'pairB']
+    frame0.pairs.typeid = [1]
+    frame0.pairs.group = [[0, 3]]
 
-    snap0.log['value'] = [1, 2, 4, 10, 12, 18, 22]
-    return snap0
+    frame0.log['value'] = [1, 2, 4, 10, 12, 18, 22]
+    return frame0
 
 
-def assert_snapshots_equal(s, snap0, check_position=True, check_step=True):
-    """Assert that two snapshots are equal."""
+def assert_frames_equal(s, frame0, check_position=True, check_step=True):
+    """Assert that two frames are equal."""
     if check_step:
-        assert s.configuration.step == snap0.configuration.step
+        assert s.configuration.step == frame0.configuration.step
 
-    assert s.configuration.dimensions == snap0.configuration.dimensions
+    assert s.configuration.dimensions == frame0.configuration.dimensions
     numpy.testing.assert_array_equal(s.configuration.box,
-                                     snap0.configuration.box)
-    assert s.particles.N == snap0.particles.N
-    assert s.particles.types == snap0.particles.types
-    assert s.particles.type_shapes == snap0.particles.type_shapes
-    numpy.testing.assert_array_equal(s.particles.typeid, snap0.particles.typeid)
-    numpy.testing.assert_array_equal(s.particles.mass, snap0.particles.mass)
+                                     frame0.configuration.box)
+    assert s.particles.N == frame0.particles.N
+    assert s.particles.types == frame0.particles.types
+    assert s.particles.type_shapes == frame0.particles.type_shapes
+    numpy.testing.assert_array_equal(s.particles.typeid, frame0.particles.typeid)
+    numpy.testing.assert_array_equal(s.particles.mass, frame0.particles.mass)
     numpy.testing.assert_array_equal(s.particles.diameter,
-                                     snap0.particles.diameter)
-    numpy.testing.assert_array_equal(s.particles.body, snap0.particles.body)
-    numpy.testing.assert_array_equal(s.particles.charge, snap0.particles.charge)
+                                     frame0.particles.diameter)
+    numpy.testing.assert_array_equal(s.particles.body, frame0.particles.body)
+    numpy.testing.assert_array_equal(s.particles.charge, frame0.particles.charge)
     numpy.testing.assert_array_equal(s.particles.moment_inertia,
-                                     snap0.particles.moment_inertia)
+                                     frame0.particles.moment_inertia)
     if check_position:
         numpy.testing.assert_array_equal(s.particles.position,
-                                         snap0.particles.position)
+                                         frame0.particles.position)
     numpy.testing.assert_array_equal(s.particles.orientation,
-                                     snap0.particles.orientation)
+                                     frame0.particles.orientation)
     numpy.testing.assert_array_equal(s.particles.velocity,
-                                     snap0.particles.velocity)
-    numpy.testing.assert_array_equal(s.particles.angmom, snap0.particles.angmom)
-    numpy.testing.assert_array_equal(s.particles.image, snap0.particles.image)
+                                     frame0.particles.velocity)
+    numpy.testing.assert_array_equal(s.particles.angmom, frame0.particles.angmom)
+    numpy.testing.assert_array_equal(s.particles.image, frame0.particles.image)
 
-    assert s.bonds.N == snap0.bonds.N
-    assert s.bonds.types == snap0.bonds.types
-    numpy.testing.assert_array_equal(s.bonds.typeid, snap0.bonds.typeid)
-    numpy.testing.assert_array_equal(s.bonds.group, snap0.bonds.group)
+    assert s.bonds.N == frame0.bonds.N
+    assert s.bonds.types == frame0.bonds.types
+    numpy.testing.assert_array_equal(s.bonds.typeid, frame0.bonds.typeid)
+    numpy.testing.assert_array_equal(s.bonds.group, frame0.bonds.group)
 
-    assert s.angles.N == snap0.angles.N
-    assert s.angles.types == snap0.angles.types
-    numpy.testing.assert_array_equal(s.angles.typeid, snap0.angles.typeid)
-    numpy.testing.assert_array_equal(s.angles.group, snap0.angles.group)
+    assert s.angles.N == frame0.angles.N
+    assert s.angles.types == frame0.angles.types
+    numpy.testing.assert_array_equal(s.angles.typeid, frame0.angles.typeid)
+    numpy.testing.assert_array_equal(s.angles.group, frame0.angles.group)
 
-    assert s.dihedrals.N == snap0.dihedrals.N
-    assert s.dihedrals.types == snap0.dihedrals.types
-    numpy.testing.assert_array_equal(s.dihedrals.typeid, snap0.dihedrals.typeid)
-    numpy.testing.assert_array_equal(s.dihedrals.group, snap0.dihedrals.group)
+    assert s.dihedrals.N == frame0.dihedrals.N
+    assert s.dihedrals.types == frame0.dihedrals.types
+    numpy.testing.assert_array_equal(s.dihedrals.typeid, frame0.dihedrals.typeid)
+    numpy.testing.assert_array_equal(s.dihedrals.group, frame0.dihedrals.group)
 
-    assert s.impropers.N == snap0.impropers.N
-    assert s.impropers.types == snap0.impropers.types
-    numpy.testing.assert_array_equal(s.impropers.typeid, snap0.impropers.typeid)
-    numpy.testing.assert_array_equal(s.impropers.group, snap0.impropers.group)
+    assert s.impropers.N == frame0.impropers.N
+    assert s.impropers.types == frame0.impropers.types
+    numpy.testing.assert_array_equal(s.impropers.typeid, frame0.impropers.typeid)
+    numpy.testing.assert_array_equal(s.impropers.group, frame0.impropers.group)
 
-    assert s.constraints.N == snap0.constraints.N
+    assert s.constraints.N == frame0.constraints.N
     numpy.testing.assert_array_equal(s.constraints.value,
-                                     snap0.constraints.value)
+                                     frame0.constraints.value)
     numpy.testing.assert_array_equal(s.constraints.group,
-                                     snap0.constraints.group)
+                                     frame0.constraints.group)
 
-    assert s.pairs.N == snap0.pairs.N
-    assert s.pairs.types == snap0.pairs.types
-    numpy.testing.assert_array_equal(s.pairs.typeid, snap0.pairs.typeid)
-    numpy.testing.assert_array_equal(s.pairs.group, snap0.pairs.group)
+    assert s.pairs.N == frame0.pairs.N
+    assert s.pairs.types == frame0.pairs.types
+    numpy.testing.assert_array_equal(s.pairs.typeid, frame0.pairs.typeid)
+    numpy.testing.assert_array_equal(s.pairs.group, frame0.pairs.group)
 
 
 def test_fallback(tmp_path, open_mode):
     """Test that properties fall back to defaults when the N changes."""
-    snap0 = make_nondefault_snapshot()
+    frame0 = make_nondefault_frame()
 
-    snap1 = gsd.hoomd.Snapshot()
-    snap1.particles.N = 2
-    snap1.particles.position = [[-2, -1, 0], [1, 3.0, 0.5]]
-    snap1.bonds.N = None
-    snap1.angles.N = None
-    snap1.dihedrals.N = None
-    snap1.impropers.N = None
-    snap1.constraints.N = None
-    snap1.pairs.N = None
+    frame1 = gsd.hoomd.Frame()
+    frame1.particles.N = 2
+    frame1.particles.position = [[-2, -1, 0], [1, 3.0, 0.5]]
+    frame1.bonds.N = None
+    frame1.angles.N = None
+    frame1.dihedrals.N = None
+    frame1.impropers.N = None
+    frame1.constraints.N = None
+    frame1.pairs.N = None
 
-    snap2 = gsd.hoomd.Snapshot()
-    snap2.particles.N = 3
-    snap2.particles.types = ['q', 's']
-    snap2.particles.type_shapes = \
+    frame2 = gsd.hoomd.Frame()
+    frame2.particles.N = 3
+    frame2.particles.types = ['q', 's']
+    frame2.particles.type_shapes = \
         [{}, {"type": "Ellipsoid", "a": 7.0, "b": 5.0, "c": 3.0}]
-    snap2.bonds.N = 3
-    snap2.angles.N = 4
-    snap2.dihedrals.N = 5
-    snap2.impropers.N = 6
-    snap2.constraints.N = 4
-    snap2.pairs.N = 7
+    frame2.bonds.N = 3
+    frame2.angles.N = 4
+    frame2.dihedrals.N = 5
+    frame2.impropers.N = 6
+    frame2.constraints.N = 4
+    frame2.pairs.N = 7
 
     with gsd.hoomd.open(name=tmp_path / "test_fallback.gsd",
                         mode=open_mode.write) as hf:
-        hf.extend([snap0, snap1, snap2])
+        hf.extend([frame0, frame1, frame2])
 
     with gsd.hoomd.open(name=tmp_path / "test_fallback.gsd",
                         mode=open_mode.read) as hf:
         assert len(hf) == 3
         s = hf[0]
 
-        assert_snapshots_equal(s, snap0)
+        assert_frames_equal(s, frame0)
         assert 'value' in s.log
-        numpy.testing.assert_array_equal(s.log['value'], snap0.log['value'])
+        numpy.testing.assert_array_equal(s.log['value'], frame0.log['value'])
 
         # test that everything but position remained the same in frame 1
         s = hf[1]
 
-        assert_snapshots_equal(s, snap0, check_position=False)
+        assert_frames_equal(s, frame0, check_position=False)
         assert 'value' in s.log
-        numpy.testing.assert_array_equal(s.log['value'], snap0.log['value'])
+        numpy.testing.assert_array_equal(s.log['value'], frame0.log['value'])
 
         # check that the third frame goes back to defaults because it has a
         # different N
@@ -346,7 +346,7 @@ def test_fallback(tmp_path, open_mode):
 
         assert s.particles.N == 3
         assert s.particles.types == ['q', 's']
-        assert s.particles.type_shapes == snap2.particles.type_shapes
+        assert s.particles.type_shapes == frame2.particles.type_shapes
         numpy.testing.assert_array_equal(
             s.particles.typeid, numpy.array([0, 0, 0], dtype=numpy.uint32))
         numpy.testing.assert_array_equal(
@@ -379,7 +379,7 @@ def test_fallback(tmp_path, open_mode):
             numpy.array([[0, 0, 0], [0, 0, 0], [0, 0, 0]], dtype=numpy.int32))
 
         assert s.bonds.N == 3
-        assert s.bonds.types == snap0.bonds.types
+        assert s.bonds.types == frame0.bonds.types
         numpy.testing.assert_array_equal(
             s.bonds.typeid, numpy.array([0, 0, 0], dtype=numpy.uint32))
         numpy.testing.assert_array_equal(
@@ -387,7 +387,7 @@ def test_fallback(tmp_path, open_mode):
             numpy.array([[0, 0], [0, 0], [0, 0]], dtype=numpy.uint32))
 
         assert s.angles.N == 4
-        assert s.angles.types == snap0.angles.types
+        assert s.angles.types == frame0.angles.types
         numpy.testing.assert_array_equal(
             s.angles.typeid, numpy.array([0, 0, 0, 0], dtype=numpy.uint32))
         numpy.testing.assert_array_equal(
@@ -396,7 +396,7 @@ def test_fallback(tmp_path, open_mode):
                         dtype=numpy.uint32))
 
         assert s.dihedrals.N == 5
-        assert s.dihedrals.types == snap0.dihedrals.types
+        assert s.dihedrals.types == frame0.dihedrals.types
         numpy.testing.assert_array_equal(
             s.dihedrals.typeid, numpy.array([0, 0, 0, 0, 0],
                                             dtype=numpy.uint32))
@@ -407,7 +407,7 @@ def test_fallback(tmp_path, open_mode):
                         dtype=numpy.uint32))
 
         assert s.impropers.N == 6
-        assert s.impropers.types == snap0.impropers.types
+        assert s.impropers.types == frame0.impropers.types
         numpy.testing.assert_array_equal(
             s.impropers.typeid,
             numpy.array([0, 0, 0, 0, 0, 0], dtype=numpy.uint32))
@@ -425,108 +425,108 @@ def test_fallback(tmp_path, open_mode):
             numpy.array([[0, 0], [0, 0], [0, 0], [0, 0]], dtype=numpy.uint32))
 
         assert s.pairs.N == 7
-        assert s.pairs.types == snap0.pairs.types
+        assert s.pairs.types == frame0.pairs.types
         numpy.testing.assert_array_equal(
             s.pairs.typeid, numpy.array([0] * 7, dtype=numpy.uint32))
         numpy.testing.assert_array_equal(
             s.pairs.group, numpy.array([[0, 0]] * 7, dtype=numpy.uint32))
 
         assert 'value' in s.log
-        numpy.testing.assert_array_equal(s.log['value'], snap0.log['value'])
+        numpy.testing.assert_array_equal(s.log['value'], frame0.log['value'])
 
 
 def test_fallback_to_frame0(tmp_path, open_mode):
     """Test that missing entries fall back to data in frame when N matches."""
-    snap0 = make_nondefault_snapshot()
+    frame0 = make_nondefault_frame()
 
-    snap1 = gsd.hoomd.Snapshot()
-    snap1.configuration.step = 200000
-    snap1.particles.N = None
-    snap1.bonds.N = None
-    snap1.angles.N = None
-    snap1.dihedrals.N = None
-    snap1.impropers.N = None
-    snap1.constraints.N = None
-    snap1.pairs.N = None
+    frame1 = gsd.hoomd.Frame()
+    frame1.configuration.step = 200000
+    frame1.particles.N = None
+    frame1.bonds.N = None
+    frame1.angles.N = None
+    frame1.dihedrals.N = None
+    frame1.impropers.N = None
+    frame1.constraints.N = None
+    frame1.pairs.N = None
 
     with gsd.hoomd.open(name=tmp_path / "test_fallback2.gsd",
                         mode=open_mode.write) as hf:
-        hf.extend([snap0, snap1])
+        hf.extend([frame0, frame1])
 
     with gsd.hoomd.open(name=tmp_path / "test_fallback2.gsd",
                         mode=open_mode.read) as hf:
         assert len(hf) == 2
 
         s = hf[1]
-        assert s.configuration.step == snap1.configuration.step
-        assert_snapshots_equal(s, snap0, check_step=False)
+        assert s.configuration.step == frame1.configuration.step
+        assert_frames_equal(s, frame0, check_step=False)
         assert 'value' in s.log
-        numpy.testing.assert_array_equal(s.log['value'], snap0.log['value'])
+        numpy.testing.assert_array_equal(s.log['value'], frame0.log['value'])
 
 
 def test_no_fallback(tmp_path, open_mode):
     """Test that writes of default quantities do not fall back to frame 0."""
-    snap0 = make_nondefault_snapshot()
+    frame0 = make_nondefault_frame()
 
-    snap1 = gsd.hoomd.Snapshot()
-    snap1.configuration.step = 200000
-    snap1.configuration.dimensions = 3
-    snap1.configuration.box = [1, 1, 1, 0, 0, 0]
-    snap1.particles.N = snap0.particles.N
-    snap1.particles.types = ['A']
-    snap1.particles.typeid = [0] * snap0.particles.N
-    snap1.particles.type_shapes = [{}]
-    snap1.particles.mass = [1.0] * snap0.particles.N
-    snap1.particles.charge = [0.0] * snap0.particles.N
-    snap1.particles.diameter = [1.0] * snap0.particles.N
-    snap1.particles.body = [-1] * snap0.particles.N
-    snap1.particles.moment_inertia = [[0, 0, 0]] * snap0.particles.N
-    snap1.particles.position = [[0, 0, 0]] * snap0.particles.N
-    snap1.particles.orientation = [[1, 0, 0, 0]] * snap0.particles.N
-    snap1.particles.velocity = [[0, 0, 0]] * snap0.particles.N
-    snap1.particles.angmom = [[0, 0, 0, 0]] * snap0.particles.N
-    snap1.particles.image = [[0, 0, 0]] * snap0.particles.N
+    frame1 = gsd.hoomd.Frame()
+    frame1.configuration.step = 200000
+    frame1.configuration.dimensions = 3
+    frame1.configuration.box = [1, 1, 1, 0, 0, 0]
+    frame1.particles.N = frame0.particles.N
+    frame1.particles.types = ['A']
+    frame1.particles.typeid = [0] * frame0.particles.N
+    frame1.particles.type_shapes = [{}]
+    frame1.particles.mass = [1.0] * frame0.particles.N
+    frame1.particles.charge = [0.0] * frame0.particles.N
+    frame1.particles.diameter = [1.0] * frame0.particles.N
+    frame1.particles.body = [-1] * frame0.particles.N
+    frame1.particles.moment_inertia = [[0, 0, 0]] * frame0.particles.N
+    frame1.particles.position = [[0, 0, 0]] * frame0.particles.N
+    frame1.particles.orientation = [[1, 0, 0, 0]] * frame0.particles.N
+    frame1.particles.velocity = [[0, 0, 0]] * frame0.particles.N
+    frame1.particles.angmom = [[0, 0, 0, 0]] * frame0.particles.N
+    frame1.particles.image = [[0, 0, 0]] * frame0.particles.N
 
-    snap1.bonds.N = snap0.bonds.N
-    snap1.bonds.types = ['A']
-    snap1.bonds.typeid = [0] * snap0.bonds.N
-    snap1.bonds.group = [[0, 0]] * snap0.bonds.N
+    frame1.bonds.N = frame0.bonds.N
+    frame1.bonds.types = ['A']
+    frame1.bonds.typeid = [0] * frame0.bonds.N
+    frame1.bonds.group = [[0, 0]] * frame0.bonds.N
 
-    snap1.angles.N = snap0.angles.N
-    snap1.angles.types = ['A']
-    snap1.angles.typeid = [0] * snap0.angles.N
-    snap1.angles.group = [[0, 0, 0]] * snap0.angles.N
+    frame1.angles.N = frame0.angles.N
+    frame1.angles.types = ['A']
+    frame1.angles.typeid = [0] * frame0.angles.N
+    frame1.angles.group = [[0, 0, 0]] * frame0.angles.N
 
-    snap1.dihedrals.N = snap0.dihedrals.N
-    snap1.dihedrals.types = ['A']
-    snap1.dihedrals.typeid = [0] * snap0.dihedrals.N
-    snap1.dihedrals.group = [[0, 0, 0, 0]] * snap0.dihedrals.N
+    frame1.dihedrals.N = frame0.dihedrals.N
+    frame1.dihedrals.types = ['A']
+    frame1.dihedrals.typeid = [0] * frame0.dihedrals.N
+    frame1.dihedrals.group = [[0, 0, 0, 0]] * frame0.dihedrals.N
 
-    snap1.impropers.N = snap0.impropers.N
-    snap1.impropers.types = ['A']
-    snap1.impropers.typeid = [0] * snap0.impropers.N
-    snap1.impropers.group = [[0, 0, 0, 0]] * snap0.impropers.N
+    frame1.impropers.N = frame0.impropers.N
+    frame1.impropers.types = ['A']
+    frame1.impropers.typeid = [0] * frame0.impropers.N
+    frame1.impropers.group = [[0, 0, 0, 0]] * frame0.impropers.N
 
-    snap1.constraints.N = snap0.constraints.N
-    snap1.constraints.value = [0] * snap0.constraints.N
-    snap1.constraints.group = [[0, 0]] * snap0.constraints.N
+    frame1.constraints.N = frame0.constraints.N
+    frame1.constraints.value = [0] * frame0.constraints.N
+    frame1.constraints.group = [[0, 0]] * frame0.constraints.N
 
-    snap1.pairs.N = snap0.pairs.N
-    snap1.pairs.types = ['A']
-    snap1.pairs.typeid = [0] * snap0.pairs.N
-    snap1.pairs.group = [[0, 0]] * snap0.pairs.N
+    frame1.pairs.N = frame0.pairs.N
+    frame1.pairs.types = ['A']
+    frame1.pairs.typeid = [0] * frame0.pairs.N
+    frame1.pairs.group = [[0, 0]] * frame0.pairs.N
 
     with gsd.hoomd.open(name=tmp_path / "test_no_fallback.gsd",
                         mode=open_mode.write) as hf:
-        hf.extend([snap0, snap1])
+        hf.extend([frame0, frame1])
 
     with gsd.hoomd.open(name=tmp_path / "test_no_fallback.gsd",
                         mode=open_mode.read) as hf:
         assert len(hf) == 2
 
         s = hf[1]
-        assert s.configuration.step == snap1.configuration.step
-        assert_snapshots_equal(s, snap1)
+        assert s.configuration.step == frame1.configuration.step
+        assert_frames_equal(s, frame1)
 
 
 def test_iteration(tmp_path, open_mode):
@@ -558,16 +558,16 @@ def test_iteration(tmp_path, open_mode):
         with pytest.raises(IndexError):
             step = hf[20]
 
-        snaps = hf[5:10]
-        steps = [snap.configuration.step for snap in snaps]
+        frames = hf[5:10]
+        steps = [frame.configuration.step for frame in frames]
         assert steps == [6, 7, 8, 9, 10]
 
-        snaps = hf[15:50]
-        steps = [snap.configuration.step for snap in snaps]
+        frames = hf[15:50]
+        steps = [frame.configuration.step for frame in frames]
         assert steps == [16, 17, 18, 19, 20]
 
-        snaps = hf[15:-3]
-        steps = [snap.configuration.step for snap in snaps]
+        frames = hf[15:-3]
+        steps = [frame.configuration.step for frame in frames]
         assert steps == [16, 17]
 
 
@@ -679,20 +679,20 @@ def test_truncate(tmp_path):
 
 def test_state(tmp_path, open_mode):
     """Test the state chunks."""
-    snap0 = gsd.hoomd.Snapshot()
+    frame0 = gsd.hoomd.Frame()
 
-    snap0.state['hpmc/sphere/radius'] = [2.0]
-    snap0.state['hpmc/sphere/orientable'] = [1]
+    frame0.state['hpmc/sphere/radius'] = [2.0]
+    frame0.state['hpmc/sphere/orientable'] = [1]
 
-    snap1 = gsd.hoomd.Snapshot()
+    frame1 = gsd.hoomd.Frame()
 
-    snap1.state['hpmc/convex_polyhedron/N'] = [3]
-    snap1.state['hpmc/convex_polyhedron/vertices'] = [[-1, -1, -1], [0, 1, 1],
+    frame1.state['hpmc/convex_polyhedron/N'] = [3]
+    frame1.state['hpmc/convex_polyhedron/vertices'] = [[-1, -1, -1], [0, 1, 1],
                                                       [1, 0, 0]]
 
     with gsd.hoomd.open(name=tmp_path / "test_state.gsd",
                         mode=open_mode.write) as hf:
-        hf.extend([snap0, snap1])
+        hf.extend([frame0, frame1])
 
     with gsd.hoomd.open(name=tmp_path / "test_state.gsd",
                         mode=open_mode.read) as hf:
@@ -700,37 +700,37 @@ def test_state(tmp_path, open_mode):
         s = hf[0]
 
         numpy.testing.assert_array_equal(s.state['hpmc/sphere/radius'],
-                                         snap0.state['hpmc/sphere/radius'])
+                                         frame0.state['hpmc/sphere/radius'])
         numpy.testing.assert_array_equal(s.state['hpmc/sphere/orientable'],
-                                         snap0.state['hpmc/sphere/orientable'])
+                                         frame0.state['hpmc/sphere/orientable'])
 
         s = hf[1]
 
         numpy.testing.assert_array_equal(
             s.state['hpmc/convex_polyhedron/N'],
-            snap1.state['hpmc/convex_polyhedron/N'])
+            frame1.state['hpmc/convex_polyhedron/N'])
         numpy.testing.assert_array_equal(
             s.state['hpmc/convex_polyhedron/vertices'],
-            snap1.state['hpmc/convex_polyhedron/vertices'])
+            frame1.state['hpmc/convex_polyhedron/vertices'])
 
 
 def test_log(tmp_path, open_mode):
     """Test the log chunks."""
-    snap0 = gsd.hoomd.Snapshot()
+    frame0 = gsd.hoomd.Frame()
 
-    snap0.log['particles/net_force'] = [[1, 2, 3], [4, 5, 6]]
-    snap0.log['particles/pair_lj_energy'] = [0, -5, -8, -3]
-    snap0.log['value/potential_energy'] = [10]
-    snap0.log['value/pressure'] = [-3]
+    frame0.log['particles/net_force'] = [[1, 2, 3], [4, 5, 6]]
+    frame0.log['particles/pair_lj_energy'] = [0, -5, -8, -3]
+    frame0.log['value/potential_energy'] = [10]
+    frame0.log['value/pressure'] = [-3]
 
-    snap1 = gsd.hoomd.Snapshot()
+    frame1 = gsd.hoomd.Frame()
 
-    snap1.log['particles/pair_lj_energy'] = [1, 2, -4, -10]
-    snap1.log['value/pressure'] = [5]
+    frame1.log['particles/pair_lj_energy'] = [1, 2, -4, -10]
+    frame1.log['value/pressure'] = [5]
 
     with gsd.hoomd.open(name=tmp_path / "test_log.gsd",
                         mode=open_mode.write) as hf:
-        hf.extend([snap0, snap1])
+        hf.extend([frame0, frame1])
 
     with gsd.hoomd.open(name=tmp_path / "test_log.gsd",
                         mode=open_mode.read) as hf:
@@ -738,27 +738,27 @@ def test_log(tmp_path, open_mode):
         s = hf[0]
 
         numpy.testing.assert_array_equal(s.log['particles/net_force'],
-                                         snap0.log['particles/net_force'])
+                                         frame0.log['particles/net_force'])
         numpy.testing.assert_array_equal(s.log['particles/pair_lj_energy'],
-                                         snap0.log['particles/pair_lj_energy'])
+                                         frame0.log['particles/pair_lj_energy'])
         numpy.testing.assert_array_equal(s.log['value/potential_energy'],
-                                         snap0.log['value/potential_energy'])
+                                         frame0.log['value/potential_energy'])
         numpy.testing.assert_array_equal(s.log['value/pressure'],
-                                         snap0.log['value/pressure'])
+                                         frame0.log['value/pressure'])
 
         s = hf[1]
 
         # unspecified entries pull from frame 0
         numpy.testing.assert_array_equal(s.log['particles/net_force'],
-                                         snap0.log['particles/net_force'])
+                                         frame0.log['particles/net_force'])
         numpy.testing.assert_array_equal(s.log['value/potential_energy'],
-                                         snap0.log['value/potential_energy'])
+                                         frame0.log['value/potential_energy'])
 
         # specified entries are different in frame 1
         numpy.testing.assert_array_equal(s.log['particles/pair_lj_energy'],
-                                         snap1.log['particles/pair_lj_energy'])
+                                         frame1.log['particles/pair_lj_energy'])
         numpy.testing.assert_array_equal(s.log['value/pressure'],
-                                         snap1.log['value/pressure'])
+                                         frame1.log['value/pressure'])
 
 
 def test_pickle(tmp_path, open_mode):
@@ -782,40 +782,40 @@ def test_no_duplicate_types(tmp_path, container):
     """Test that duplicate types raise an error."""
     with gsd.hoomd.open(name=tmp_path / "test_create.gsd", mode='wb') as hf:
 
-        snap = gsd.hoomd.Snapshot()
+        frame = gsd.hoomd.Frame()
 
-        getattr(snap, container).types = ['A', 'B', 'B', 'C']
+        getattr(frame, container).types = ['A', 'B', 'B', 'C']
 
         with pytest.raises(ValueError):
-            hf.append(snap)
+            hf.append(frame)
 
 
 def test_read_log(tmp_path):
     """Test that data logged in gsd files are read correctly."""
-    snap0 = gsd.hoomd.Snapshot()
-    snap0.log['particles/pair_lj_energy'] = [0, -5, -8, -3]
-    snap0.log['particles/pair_lj_force'] = [
+    frame0 = gsd.hoomd.Frame()
+    frame0.log['particles/pair_lj_energy'] = [0, -5, -8, -3]
+    frame0.log['particles/pair_lj_force'] = [
         (0, 0, 0),
         (1, 1, 1),
         (2, 2, 2),
         (3, 3, 3),
     ]
-    snap0.log['value/potential_energy'] = [10]
-    snap0.log['value/pressure'] = [-3]
+    frame0.log['value/potential_energy'] = [10]
+    frame0.log['value/pressure'] = [-3]
 
-    snap1 = gsd.hoomd.Snapshot()
-    snap1.configuration.step = 1
-    snap1.log['particles/pair_lj_energy'] = [1, 2, -4, -10]
-    snap1.log['particles/pair_lj_force'] = [
+    frame1 = gsd.hoomd.Frame()
+    frame1.configuration.step = 1
+    frame1.log['particles/pair_lj_energy'] = [1, 2, -4, -10]
+    frame1.log['particles/pair_lj_force'] = [
         (1, 1, 1),
         (2, 2, 2),
         (3, 3, 3),
         (4, 4, 4),
     ]
-    snap1.log['value/pressure'] = [5]
+    frame1.log['value/pressure'] = [5]
 
     with gsd.hoomd.open(name=tmp_path / "test_log.gsd", mode='wb') as hf:
-        hf.extend([snap0, snap1])
+        hf.extend([frame0, frame1])
 
     # Test scalar_only = False
     logged_data_dict = gsd.hoomd.read_log(name=tmp_path / "test_log.gsd",
@@ -832,22 +832,22 @@ def test_read_log(tmp_path):
                                      [0, 1])
     numpy.testing.assert_array_equal(
         logged_data_dict['log/particles/pair_lj_energy'], [
-            snap0.log['particles/pair_lj_energy'],
-            snap1.log['particles/pair_lj_energy']
+            frame0.log['particles/pair_lj_energy'],
+            frame1.log['particles/pair_lj_energy']
         ])
     numpy.testing.assert_array_equal(
         logged_data_dict['log/particles/pair_lj_force'], [
-            snap0.log['particles/pair_lj_force'],
-            snap1.log['particles/pair_lj_force']
+            frame0.log['particles/pair_lj_force'],
+            frame1.log['particles/pair_lj_force']
         ])
     numpy.testing.assert_array_equal(
         logged_data_dict['log/value/potential_energy'], [
-            *snap0.log['value/potential_energy'],
-            *snap0.log['value/potential_energy']
+            *frame0.log['value/potential_energy'],
+            *frame0.log['value/potential_energy']
         ])
     numpy.testing.assert_array_equal(
         logged_data_dict['log/value/pressure'],
-        [*snap0.log['value/pressure'], *snap1.log['value/pressure']])
+        [*frame0.log['value/pressure'], *frame1.log['value/pressure']])
 
     # Test scalar_only = True
     logged_data_dict = gsd.hoomd.read_log(name=tmp_path / "test_log.gsd",
@@ -860,16 +860,16 @@ def test_read_log(tmp_path):
                                      [0, 1])
     numpy.testing.assert_array_equal(
         logged_data_dict['log/value/potential_energy'], [
-            *snap0.log['value/potential_energy'],
-            *snap0.log['value/potential_energy']
+            *frame0.log['value/potential_energy'],
+            *frame0.log['value/potential_energy']
         ])
     numpy.testing.assert_array_equal(
         logged_data_dict['log/value/pressure'],
-        [*snap0.log['value/pressure'], *snap1.log['value/pressure']])
+        [*frame0.log['value/pressure'], *frame1.log['value/pressure']])
 
     # No logged data
     with gsd.hoomd.open(name=tmp_path / "test_log.gsd", mode='wb') as hf:
-        hf.extend([gsd.hoomd.Snapshot(), gsd.hoomd.Snapshot()])
+        hf.extend([gsd.hoomd.Frame(), gsd.hoomd.Frame()])
     with pytest.raises(RuntimeError):
         logged_data_dict = gsd.hoomd.read_log(name=str(tmp_path
                                                        / "test_log.gsd"))

--- a/scripts/benchmark-hoomd.py
+++ b/scripts/benchmark-hoomd.py
@@ -20,19 +20,19 @@ from subprocess import call, PIPE
 
 def write_frame(file, frame, position, orientation):
     """Write a frame to the file."""
-    snap = gsd.hoomd.Snapshot()
-    snap.particles.N = position.shape[0]
-    snap.configuration.step = frame * 10
+    frame = gsd.hoomd.Frame()
+    frame.particles.N = position.shape[0]
+    frame.configuration.step = frame * 10
     position[0][0] = frame
     orientation[0][0] = frame
-    snap.particles.position = position
-    snap.particles.orientation = orientation
-    file.append(snap)
+    frame.particles.position = position
+    frame.particles.orientation = orientation
+    file.append(frame)
 
 
-def read_frame(file, frame, position, orientation):
+def read_frame(file, frame_idx, position, orientation):
     """Read a frame from the file."""
-    snap = file[frame]  # noqa
+    frame = file[frame_idx]  # noqa
 
 
 def write_file(file, nframes, N, position, orientation):


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Base backwards compatible bug fixes on `trunk-patch`. -->
<!-- Base additional functionality on `trunk-minor`. -->
<!-- Base API incompatible changes on `trunk-major`. -->

## Description

<!-- Describe your changes in detail. -->
* Rename `Snapshot` to `Frame` and deprecate `Snapshot`.
* Continue providing `Snapshot` for backwards compatibility in v2.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Users confuse `gsd.hoomd.Snapshot` with `hoomd.Snapshot`. Rename the former to `gsd.hoomd.Frame` to prevent confusion.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
I reviewed the documentation and updated all unit tests. For compatibility with `isinstance` checks, `Frame` is a subclass of `Snapshot`, so all unit tests implicitly test `Snapshot` and `Frame`.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added:

* ``gsd.hoomd.Frame`` class to replace ``gsd.hoomd.Snapshot``.

Deprecated:

* ``gsd.hoomd.Snapshot``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
