### PR TITLE
Reduce memory usage.

### DIFF
--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -58,10 +58,16 @@ enum
     GSD_INITIAL_FRAME_INDEX_SIZE = 16
     };
 
-/// Size of write buffer
+/// Initial size of write buffer
 enum
     {
-    GSD_WRITE_BUFFER_SIZE = 16 * 1024 * 1024
+    GSD_INITIAL_WRITE_BUFFER_SIZE = 1024
+    };
+
+/// Maximum size of write buffer
+enum
+    {
+    GSD_MAXIMUM_WRITE_BUFFER_SIZE = 16 * 1024 * 1024
     };
 
 /// Size of copy buffer
@@ -1570,7 +1576,7 @@ inline static int gsd_initialize_handle(struct gsd_handle* handle)
             return retval;
             }
 
-        retval = gsd_byte_buffer_allocate(&handle->write_buffer, GSD_WRITE_BUFFER_SIZE);
+        retval = gsd_byte_buffer_allocate(&handle->write_buffer, GSD_INITIAL_WRITE_BUFFER_SIZE);
         if (retval != GSD_SUCCESS)
             {
             return retval;
@@ -1994,10 +2000,10 @@ int gsd_write_chunk(struct gsd_handle* handle,
     size_t size = N * M * gsd_sizeof_type(type);
 
     // decide whether to write this chunk to the buffer or straight to disk
-    if (size < handle->write_buffer.reserved / 2)
+    if (size < GSD_MAXIMUM_WRITE_BUFFER_SIZE / 2)
         {
         // flush the buffer if this entry won't fit
-        if (size > (handle->write_buffer.reserved - handle->write_buffer.size))
+        if (size > (GSD_MAXIMUM_WRITE_BUFFER_SIZE - handle->write_buffer.size))
             {
             gsd_flush_write_buffer(handle);
             }


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Base backwards compatible bug fixes on `trunk-patch`. -->
<!-- Base additional functionality on `trunk-minor`. -->
<!-- Base API incompatible changes on `trunk-major`. -->

## Description

<!-- Describe your changes in detail. -->
Allocate a small write buffer at first, then expand the write buffer as needed up to the maximum.

## Motivation and Context

Previously, *gsd* always allocated a 16MB write buffer. For many files, much of this is left unused.

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
I checked the final reserved size in the write buffer for a number of test write patterns and observed the expected behavior.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Reduce memory usage.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
