### PR TITLE
Fix corruption

### DIFF
--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -1894,6 +1894,13 @@ int gsd_end_frame(struct gsd_handle* handle)
         return retval;
         }
 
+    // sync the data before writing the index
+    retval = fsync(handle->fd);
+    if (retval != 0)
+        {
+        return GSD_ERROR_IO;
+        }
+
     // write the frame index to the file
     if (handle->frame_index.size > 0)
         {

--- a/scripts/benchmark-write.cc
+++ b/scripts/benchmark-write.cc
@@ -17,7 +17,7 @@ int main(int argc, char** argv) // NOLINT
     {
     const size_t n_keys = 16;
     const size_t n_frames = 100;
-    const size_t key_size = 1024*1024;
+    const size_t key_size = 1024 * 1024;
 
     std::vector<double> data(key_size);
 
@@ -68,7 +68,8 @@ int main(int argc, char** argv) // NOLINT
 
     const double us = 1e-6;
     std::cout << "Write time: " << time_per_key / us << " microseconds/key." << std::endl;
-    std::cout << "Write time: " << time_per_key / us * n_keys << " microseconds/frame." << std::endl;
+    std::cout << "Write time: " << time_per_key / us * n_keys << " microseconds/frame."
+              << std::endl;
 
     const double mb_per_second = double(key_size * 8 + 32 * 2) / 1048576.0 / time_per_key;
     std::cout << "MB/s: " << mb_per_second << " MB/s." << std::endl;

--- a/scripts/benchmark-write.cc
+++ b/scripts/benchmark-write.cc
@@ -17,7 +17,7 @@ int main(int argc, char** argv) // NOLINT
     {
     const size_t n_keys = 16;
     const size_t n_frames = 100;
-    const size_t key_size = 1024 * 1024;
+    const size_t key_size = static_cast<const size_t>(1024) * static_cast<const size_t>(1024);
 
     std::vector<double> data(key_size);
 
@@ -71,7 +71,9 @@ int main(int argc, char** argv) // NOLINT
     std::cout << "Write time: " << time_per_key / us * n_keys << " microseconds/frame."
               << std::endl;
 
-    const double mb_per_second = double(key_size * 8 + 32 * 2) / 1048576.0 / time_per_key;
+    const double mb_per_second
+        = double(key_size * 8 + static_cast<const size_t>(32) * static_cast<const size_t>(2))
+          / 1048576.0 / time_per_key;
     std::cout << "MB/s: " << mb_per_second << " MB/s." << std::endl;
 
     gsd_close(&handle);

--- a/scripts/benchmark-write.cc
+++ b/scripts/benchmark-write.cc
@@ -15,11 +15,17 @@
 
 int main(int argc, char** argv) // NOLINT
     {
-    const size_t n_keys = 65534;
-    const size_t n_frames = 1000;
-    const size_t key_size = 1;
+    const size_t n_keys = 16;
+    const size_t n_frames = 100;
+    const size_t key_size = 1024*1024;
 
     std::vector<double> data(key_size);
+
+    for (size_t i = 0; i < key_size; i++)
+        {
+        data[i] = (double)i;
+        }
+
     std::vector<std::string> names;
     for (size_t i = 0; i < n_keys; i++)
         {
@@ -62,6 +68,10 @@ int main(int argc, char** argv) // NOLINT
 
     const double us = 1e-6;
     std::cout << "Write time: " << time_per_key / us << " microseconds/key." << std::endl;
+    std::cout << "Write time: " << time_per_key / us * n_keys << " microseconds/frame." << std::endl;
+
+    const double mb_per_second = double(key_size * 8 + 32 * 2) / 1048576.0 / time_per_key;
+    std::cout << "MB/s: " << mb_per_second << " MB/s." << std::endl;
 
     gsd_close(&handle);
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Base backwards compatible bug fixes on `trunk-patch`. -->
<!-- Base additional functionality on `trunk-minor`. -->
<!-- Base API incompatible changes on `trunk-major`. -->

## Description

<!-- Describe your changes in detail. -->
Synchronize the data to the file before writing the index.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In some cases, especially on Summit, users obtained corrupt files with index entries pointing past the end of the file. As far as I can tell, the only way this could happen is if the job was killed after `gsd_end_frame` was called and somehow the OS wrote the cached index to the file but not the cached data. 

Adding the `fsync` in this PR ensures that the data is written before the index. With this, a job kill should lead to files with the data, but possibly not the index pointing to that data. Such files are valid gsd files.

## How Has This Been Tested?

The failure mode is difficult to trigger. Time will tell if users still have the reported issue after this change.

I tested performance with and without the `fsync` on 1) a local NVME drive 2) a NFS mounted partition and 3) a lustre filesystem on Great Lakes and 4) a GPFS filesystem on Summit. In all cases, the `fysync` reduced performance to varying degrees. Frames with smaller amounts of data have higher performance penalties in general. Summit's GPFS system suffered the worst performance degradation, especially for frame size of just over 32 kiB.

The `fsync` is necessary to make the file writes resilient to job kills, which is a primary design goal for GSD. If users find the performance degradation too severe, then the only solution I see is to add an API that allows users to instruct GSD to buffer *N* frames before syncing. This would allow users some control over how much data they are willing to give up in a job kill to gain the performance of buffering many frame writes together. However, it increases complexity for the user and we should only add this if necessary. The change I would propose, if needed, would be to hold data in `write_buffer` and `frame_index` for N frames and only then issue the data write, sync, and index write calls. `gsd_close` would also need to flush any data left in the buffers.

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Reduce likelihood  of data corruption when writing GSD files.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
