### PR TITLE
Test on gcc9, clang10, Python 3.8, and newer.

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, windows, macos]
-        python_version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python_version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3.5.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     name: Build release tarball
     runs-on: ubuntu-latest
     container:
-      image: glotzerlab/ci:2022.11-ubuntu22.04
+      image: glotzerlab/ci:2023.03-ubuntu22.04
       options: -u 0
 
     steps:

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -24,7 +24,7 @@ jobs:
     name: Run clang-tidy
     runs-on: ubuntu-latest
     container:
-      image: glotzerlab/ci:2022.11-clang14_py311
+      image: glotzerlab/ci:2023.03-clang14_py311
     steps:
       - uses: actions/checkout@v3.5.0
       - name: Configure

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -31,7 +31,7 @@ jobs:
     name: Unit test on Linux [${{ matrix.image }}]
     runs-on: ubuntu-latest
     container:
-      image: glotzerlab/ci:2022.11-${{ matrix.image }}
+      image: glotzerlab/ci:2023.03-${{ matrix.image }}
       options: -u 0
     strategy:
       matrix:
@@ -43,14 +43,7 @@ jobs:
                 clang11_py310,
                 gcc10_py310,
                 gcc9_py39,
-                clang10_py38,
-                clang9_py38,
-                clang8_py38,
-                clang7_py38,
-                gcc8_py37,
-                gcc7_py37,
-                clang6_py37,
-                gcc7_py36]
+                clang10_py38]
 
     steps:
       - uses: actions/checkout@v3.5.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,14 @@ Change Log
 v2.x
 ----
 
+v2.9.0 (not yet released)
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Changed:*
+
+* Test on gcc9, clang10, and newer.
+* Test and provide binary wheels on Python 3.8 and newer.
+
 v2.8.1 (2023-03-13)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/INSTALLING.rst
+++ b/INSTALLING.rst
@@ -111,9 +111,9 @@ Install prerequisites
 
 **General requirements:**
 
-* **C compiler** (tested with gcc 7-12, clang 6-14, visual studio 2019-2022)
-* **Python** >= 3.6
-* **numpy** >= 1.9.3
+* **C compiler** (tested with gcc 9-12, clang 10-14, visual studio 2019-2022)
+* **Python** >= 3.8
+* **numpy** >= 1.17.3
 * **Cython** >= 0.22
 
 **To build the documentation**:


### PR DESCRIPTION
Also, provide only Python 3.8 and newer wheels.

<!-- Please confirm that your work is based on the correct branch. -->
<!-- Base backwards compatible bug fixes on `trunk-patch`. -->
<!-- Base additional functionality on `trunk-minor`. -->
<!-- Base API incompatible changes on `trunk-major`. -->

## Description

<!-- Describe your changes in detail. -->
Update CI tests and build scripts.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
I follow the default versions available in the oldest support Ubuntu LTS release. Ubuntu 18.04 is end of life in June 2023 (https://wiki.ubuntu.com/Releases). Ubuntu 20.04 provides gcc9, clang10, and Python 3.8.

`conda-forge` has already moved to a Python 3.8 minimum.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->
See the checks on this pull request.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
