### PR TITLE
Deprecate write-only file modes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Create a hoomd gsd file.
 >>> s.particles.typeid = [0,0,1,1]
 >>> s.particles.position = [[0,0,0],[1,1,1], [-1,-1,-1], [1,-1,-1]]
 >>> s.configuration.box = [3, 3, 3, 0, 0, 0]
->>> traj = gsd.hoomd.open(name='test.gsd', mode='wb+')
+>>> traj = gsd.hoomd.open(name='test.gsd', mode='w')
 >>> traj.append(s)
 ```
 
@@ -48,7 +48,7 @@ Append frames to a gsd file:
 
 Randomly index frames:
 ```python
->>> with gsd.hoomd.open('test.gsd', 'rb') as t:
+>>> with gsd.hoomd.open('test.gsd', 'r') as t:
 ...     frame = t[5]
 ...     print(frame.configuration.step)
 4
@@ -67,7 +67,7 @@ Randomly index frames:
 
 Slice frames:
 ```python
->>> with gsd.hoomd.open('test.gsd', 'rb') as t:
+>>> with gsd.hoomd.open('test.gsd', 'r') as t:
 ...     for s in t[5:-2]:
 ...         print(s.configuration.step, end=' ')
 4 5 6 7
@@ -76,7 +76,7 @@ Slice frames:
 ## File layer examples
 
 ```python
-with gsd.fl.open(name='file.gsd', mode='wb+') as f:
+with gsd.fl.open(name='file.gsd', mode='w') as f:
     f.write_chunk(name='position', data=numpy.array([[1,2,3],[4,5,6]], dtype=numpy.float32));
     f.write_chunk(name='angle', data=numpy.array([0, 1], dtype=numpy.float32));
     f.write_chunk(name='box', data=numpy.array([10, 10, 10], dtype=numpy.float32));
@@ -84,7 +84,7 @@ with gsd.fl.open(name='file.gsd', mode='wb+') as f:
 ```
 
 ```python
-with gsd.fl.open(name='file.gsd', mode='rb') as f:
+with gsd.fl.open(name='file.gsd', mode='r') as f:
     for i in range(1,f.nframes):
         position = f.read_chunk(frame=i, name='position');
         do_something(position);

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Create a hoomd gsd file.
 >>> s.particles.typeid = [0,0,1,1]
 >>> s.particles.position = [[0,0,0],[1,1,1], [-1,-1,-1], [1,-1,-1]]
 >>> s.configuration.box = [3, 3, 3, 0, 0, 0]
->>> traj = gsd.hoomd.open(name='test.gsd', mode='wb')
+>>> traj = gsd.hoomd.open(name='test.gsd', mode='wb+')
 >>> traj.append(s)
 ```
 
@@ -76,7 +76,7 @@ Slice frames:
 ## File layer examples
 
 ```python
-with gsd.fl.open(name='file.gsd', mode='wb') as f:
+with gsd.fl.open(name='file.gsd', mode='wb+') as f:
     f.write_chunk(name='position', data=numpy.array([[1,2,3],[4,5,6]], dtype=numpy.float32));
     f.write_chunk(name='angle', data=numpy.array([0, 1], dtype=numpy.float32));
     f.write_chunk(name='box', data=numpy.array([10, 10, 10], dtype=numpy.float32));

--- a/doc/fl-examples.rst
+++ b/doc/fl-examples.rst
@@ -25,7 +25,7 @@ Open a gsd file
 .. ipython:: python
 
     f = gsd.fl.open(name="file.gsd",
-                    mode='wb+',
+                    mode='w',
                     application="My application",
                     schema="My Schema",
                     schema_version=[1,0])
@@ -57,7 +57,7 @@ Write data
 .. ipython:: python
 
     f = gsd.fl.open(name="file.gsd",
-                    mode='wb+',
+                    mode='w',
                     application="My application",
                     schema="My Schema",
                     schema_version=[1,0]);
@@ -90,7 +90,7 @@ Read data
 
 .. ipython:: python
 
-    f = gsd.fl.open(name="file.gsd", mode='rb')
+    f = gsd.fl.open(name="file.gsd", mode='r')
     f.read_chunk(frame=0, name='chunk1')
     f.read_chunk(frame=1, name='chunk2')
     f.close()
@@ -103,7 +103,7 @@ Test if a chunk exists
 
 .. ipython:: python
 
-    f = gsd.fl.open(name="file.gsd", mode='rb')
+    f = gsd.fl.open(name="file.gsd", mode='r')
     f.chunk_exists(frame=0, name='chunk1')
     f.chunk_exists(frame=1, name='chunk2')
     f.chunk_exists(frame=2, name='chunk1')
@@ -117,7 +117,7 @@ Discover chunk names
 
 .. ipython:: python
 
-    f = gsd.fl.open(name="file.gsd", mode='rb')
+    f = gsd.fl.open(name="file.gsd", mode='r')
     f.find_matching_chunk_names('')
     f.find_matching_chunk_names('chunk')
     f.find_matching_chunk_names('chunk1')
@@ -132,7 +132,7 @@ Read-only access
 .. ipython:: python
     :okexcept:
 
-    f = gsd.fl.open(name="file.gsd", mode='rb')
+    f = gsd.fl.open(name="file.gsd", mode='r')
     if f.chunk_exists(frame=0, name='chunk1'):
         data = f.read_chunk(frame=0, name='chunk1')
     data
@@ -147,7 +147,7 @@ Access file metadata
 
 .. ipython:: python
 
-    f = gsd.fl.open(name="file.gsd", mode='rb')
+    f = gsd.fl.open(name="file.gsd", mode='r')
     f.name
     f.mode
     f.gsd_version
@@ -165,7 +165,7 @@ Open a file in read/write mode
 .. ipython:: python
 
     f = gsd.fl.open(name="file.gsd",
-                    mode='wb+',
+                    mode='w',
                     application="My application",
                     schema="My Schema",
                     schema_version=[1,0])
@@ -181,7 +181,7 @@ Use as a context manager
 
 .. ipython:: python
 
-    with gsd.fl.open(name="file.gsd", mode='rb') as f:
+    with gsd.fl.open(name="file.gsd", mode='r') as f:
         data = f.read_chunk(frame=0, name='double');
     data
 
@@ -194,7 +194,7 @@ Store string chunks
 .. ipython:: python
 
     f = gsd.fl.open(name="file.gsd",
-                    mode='wb+',
+                    mode='w',
                     application="My application",
                     schema="My Schema",
                     schema_version=[1,0])
@@ -219,7 +219,7 @@ Truncate
 
 .. ipython:: python
 
-    f = gsd.fl.open(name="file.gsd", mode='rb+')
+    f = gsd.fl.open(name="file.gsd", mode='r+')
     f.nframes
     f.schema, f.schema_version, f.application
     f.truncate()

--- a/doc/fl-examples.rst
+++ b/doc/fl-examples.rst
@@ -25,7 +25,7 @@ Open a gsd file
 .. ipython:: python
 
     f = gsd.fl.open(name="file.gsd",
-                    mode='wb',
+                    mode='wb+',
                     application="My application",
                     schema="My Schema",
                     schema_version=[1,0])
@@ -57,7 +57,7 @@ Write data
 .. ipython:: python
 
     f = gsd.fl.open(name="file.gsd",
-                    mode='wb',
+                    mode='wb+',
                     application="My application",
                     schema="My Schema",
                     schema_version=[1,0]);
@@ -176,23 +176,6 @@ Open a file in read/write mode
 
 Open a file in read/write mode to allow both reading and writing.
 
-Write a file in append mode
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. ipython:: python
-    :okexcept:
-
-    f = gsd.fl.open(name="file.gsd", mode='ab')
-    f.write_chunk(name='int', data=numpy.array([10,20], dtype=numpy.int16));
-    f.end_frame()
-    f.nframes
-    # Reads fail in append mode
-    f.read_chunk(frame=2, name='double')
-    f.close()
-
-Open a file in append mode to write additional chunks to an existing file,
-but prevent reading.
-
 Use as a context manager
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -236,7 +219,7 @@ Truncate
 
 .. ipython:: python
 
-    f = gsd.fl.open(name="file.gsd", mode='ab')
+    f = gsd.fl.open(name="file.gsd", mode='rb+')
     f.nframes
     f.schema, f.schema_version, f.application
     f.truncate()

--- a/doc/hoomd-examples.rst
+++ b/doc/hoomd-examples.rst
@@ -39,7 +39,7 @@ Create a hoomd gsd file
 
 .. ipython:: python
 
-    f = gsd.hoomd.open(name='file.gsd', mode='wb+')
+    f = gsd.hoomd.open(name='file.gsd', mode='w')
     @suppress
     f.close()
 
@@ -57,7 +57,7 @@ Write frames to a gsd file
         frame.particles.position = numpy.random.random(size=(4+i,3))
         return frame
 
-    f = gsd.hoomd.open(name='example.gsd', mode='wb+')
+    f = gsd.hoomd.open(name='example.gsd', mode='w')
     f.extend( (create_frame(i) for i in range(10)) )
     f.append( create_frame(10) )
     len(f)
@@ -80,7 +80,7 @@ Randomly index frames
 
 .. ipython:: python
 
-    f = gsd.hoomd.open(name='example.gsd', mode='rb')
+    f = gsd.hoomd.open(name='example.gsd', mode='r')
     frame = f[5]
     frame.configuration.step
     frame.particles.N
@@ -99,7 +99,7 @@ trajectory.
 
 .. ipython:: python
 
-    f = gsd.hoomd.open(name='example.gsd', mode='rb')
+    f = gsd.hoomd.open(name='example.gsd', mode='r')
 
     for frame in f[5:-2]:
         print(frame.configuration.step, end=' ')
@@ -139,7 +139,7 @@ Access logged data
 
 .. ipython:: python
 
-    with gsd.hoomd.open(name='log-example.gsd', mode='wb+') as f:
+    with gsd.hoomd.open(name='log-example.gsd', mode='w') as f:
         frame = gsd.hoomd.Frame()
         frame.particles.N = 4
         for i in range(10):
@@ -173,7 +173,7 @@ Read logged data from the ``log`` dictionary.
     .. ipython:: python
         :okexcept:
 
-        with gsd.hoomd.open(name='example.gsd', mode='wb+') as f:
+        with gsd.hoomd.open(name='example.gsd', mode='w') as f:
             frame = gsd.hoomd.Frame()
             frame.particles.N = 4
             frame.log['invalid'] = dict(a=1, b=5)
@@ -190,7 +190,7 @@ Use multiprocessing
       t, frame_idx = args
       return len(t[frame_idx].particles.position)
 
-   with gsd.hoomd.open(name='example.gsd', mode='rb') as t:
+   with gsd.hoomd.open(name='example.gsd', mode='r') as t:
       with multiprocessing.Pool(processes=multiprocessing.cpu_count()) as pool:
          result = pool.map(count_particles, [(t, frame_idx) for frame_idx in range(len(t))])
 

--- a/doc/hoomd-examples.rst
+++ b/doc/hoomd-examples.rst
@@ -39,7 +39,7 @@ Create a hoomd gsd file
 
 .. ipython:: python
 
-    f = gsd.hoomd.open(name='file.gsd', mode='wb')
+    f = gsd.hoomd.open(name='file.gsd', mode='wb+')
     @suppress
     f.close()
 
@@ -57,7 +57,7 @@ Write frames to a gsd file
         frame.particles.position = numpy.random.random(size=(4+i,3))
         return frame
 
-    f = gsd.hoomd.open(name='example.gsd', mode='wb')
+    f = gsd.hoomd.open(name='example.gsd', mode='wb+')
     f.extend( (create_frame(i) for i in range(10)) )
     f.append( create_frame(10) )
     len(f)
@@ -139,7 +139,7 @@ Access logged data
 
 .. ipython:: python
 
-    with gsd.hoomd.open(name='log-example.gsd', mode='wb') as f:
+    with gsd.hoomd.open(name='log-example.gsd', mode='wb+') as f:
         frame = gsd.hoomd.Frame()
         frame.particles.N = 4
         for i in range(10):
@@ -173,7 +173,7 @@ Read logged data from the ``log`` dictionary.
     .. ipython:: python
         :okexcept:
 
-        with gsd.hoomd.open(name='example.gsd', mode='wb') as f:
+        with gsd.hoomd.open(name='example.gsd', mode='wb+') as f:
             frame = gsd.hoomd.Frame()
             frame.particles.N = 4
             frame.log['invalid'] = dict(a=1, b=5)

--- a/doc/python-api.rst
+++ b/doc/python-api.rst
@@ -11,7 +11,7 @@ Submodules
 ----------
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 1
 
    python-module-gsd.fl
    python-module-gsd.hoomd

--- a/gsd/__main__.py
+++ b/gsd/__main__.py
@@ -68,7 +68,7 @@ def main_read(args):
         })
         attributes.update({"Number of frames": len(traj)})
     else:
-        if args.mode not in ['rb', 'rb+', 'ab']:
+        if args.mode not in ['rb', 'rb+', 'a', 'r', 'r+']:
             raise ValueError("Unsupported schema for creating a file.")
         handle = fl.open(args.file, args.mode)
         local_ns.update({
@@ -120,8 +120,8 @@ def main():
         '-m',
         '--mode',
         type=str,
-        default='rb',
-        choices=['rb', 'rb+', 'wb', 'wb+', 'xb', 'xb+', 'ab'],
+        default='r',
+        choices=['rb', 'rb+', 'wb', 'wb+', 'xb', 'xb+', 'ab', 'w', 'r', 'r+', 'x', 'a',],
         help="The file mode.")
     parser_read.set_defaults(func=main_read)
 

--- a/gsd/__main__.py
+++ b/gsd/__main__.py
@@ -116,13 +116,25 @@ def main():
                              default='hoomd',
                              choices=['hoomd', 'none'],
                              help="The file schema.")
-    parser_read.add_argument(
-        '-m',
-        '--mode',
-        type=str,
-        default='r',
-        choices=['rb', 'rb+', 'wb', 'wb+', 'xb', 'xb+', 'ab', 'w', 'r', 'r+', 'x', 'a',],
-        help="The file mode.")
+    parser_read.add_argument('-m',
+                             '--mode',
+                             type=str,
+                             default='r',
+                             choices=[
+                                 'rb',
+                                 'rb+',
+                                 'wb',
+                                 'wb+',
+                                 'xb',
+                                 'xb+',
+                                 'ab',
+                                 'w',
+                                 'r',
+                                 'r+',
+                                 'x',
+                                 'a',
+                             ],
+                             help="The file mode.")
     parser_read.set_defaults(func=main_read)
 
     # This is a hack, as argparse itself does not

--- a/gsd/__main__.py
+++ b/gsd/__main__.py
@@ -68,7 +68,7 @@ def main_read(args):
         })
         attributes.update({"Number of frames": len(traj)})
     else:
-        if args.mode not in ['rb', 'rb+', 'a', 'r', 'r+']:
+        if args.mode not in ['rb', 'rb+', 'ab', 'a', 'r', 'r+']:
             raise ValueError("Unsupported schema for creating a file.")
         handle = fl.open(args.file, args.mode)
         local_ns.update({

--- a/gsd/fl.pyx
+++ b/gsd/fl.pyx
@@ -16,6 +16,7 @@ import logging
 import numpy
 import os
 from pickle import PickleError
+import warnings
 from libc.stdint cimport uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t,\
     uint64_t, int64_t
 from libc.errno cimport errno
@@ -205,11 +206,16 @@ def open(name, mode, application=None, schema=None, schema_version=None):
     ``application``, ``schema``, and ``schema_version`` are saved in the file
     and must not be None.
 
+    .. deprecated:: 2.9.0
+
+        The following values to ``mode`` are deprecated: ``'ab'``, ``'xb'``,
+        and ``'wb'``.
+
     Example:
 
         .. ipython:: python
 
-            with gsd.fl.open(name='file.gsd', mode='wb',
+            with gsd.fl.open(name='file.gsd', mode='wb+',
                              application="My application", schema="My Schema",
                              schema_version=[1,0]) as f:
                 f.write_chunk(name='chunk1',
@@ -301,6 +307,8 @@ cdef class GSDFile:
         if mode == 'wb':
             c_flags = libgsd.GSD_OPEN_APPEND
             overwrite = 1
+            warnings.warn("The 'wb' mode is deprecated, use 'wb+'",
+                           FutureWarning)
         elif mode == 'wb+':
             c_flags = libgsd.GSD_OPEN_READWRITE
             overwrite = 1
@@ -312,12 +320,16 @@ cdef class GSDFile:
             c_flags = libgsd.GSD_OPEN_APPEND
             overwrite = 1
             exclusive_create = 1
+            warnings.warn("The 'xb' mode is deprecated, use 'xb+'",
+                           FutureWarning)
         elif mode == 'xb+':
             c_flags = libgsd.GSD_OPEN_READWRITE
             overwrite = 1
             exclusive_create = 1
         elif mode == 'ab':
             c_flags = libgsd.GSD_OPEN_APPEND
+            warnings.warn("The 'ab' mode is deprecated, use 'rb+'",
+                           FutureWarning)
         else:
             raise ValueError("mode must be 'wb', 'wb+', 'rb', 'rb+', "
                              "'xb', 'xb+', or 'ab'")
@@ -431,7 +443,7 @@ cdef class GSDFile:
         Example:
             .. ipython:: python
 
-                with gsd.fl.open(name='file.gsd', mode='wb',
+                with gsd.fl.open(name='file.gsd', mode='wb+',
                                  application="My application",
                                  schema="My Schema", schema_version=[1,0]) as f:
                     for i in range(10):
@@ -440,7 +452,7 @@ cdef class GSDFile:
                                                        dtype=numpy.float32))
                         f.end_frame()
 
-                f = gsd.fl.open(name='file.gsd', mode='ab',
+                f = gsd.fl.open(name='file.gsd', mode='rb+',
                                 application="My application",
                                 schema="My Schema", schema_version=[1,0])
                 f.nframes
@@ -476,7 +488,7 @@ cdef class GSDFile:
         Example:
             .. ipython:: python
 
-                f = gsd.fl.open(name='file.gsd', mode='wb',
+                f = gsd.fl.open(name='file.gsd', mode='wb+',
                                 application="My application",
                                 schema="My Schema", schema_version=[1,0])
 
@@ -527,7 +539,7 @@ cdef class GSDFile:
         Example:
             .. ipython:: python
 
-                f = gsd.fl.open(name='file.gsd', mode='wb',
+                f = gsd.fl.open(name='file.gsd', mode='wb+',
                                 application="My application",
                                 schema="My Schema", schema_version=[1,0])
 
@@ -636,7 +648,7 @@ cdef class GSDFile:
         Example:
             .. ipython:: python
 
-                with gsd.fl.open(name='file.gsd', mode='wb',
+                with gsd.fl.open(name='file.gsd', mode='wb+',
                                  application="My application",
                                  schema="My Schema", schema_version=[1,0]) as f:
                     f.write_chunk(name='chunk1',
@@ -703,7 +715,7 @@ cdef class GSDFile:
             .. ipython:: python
                 :okexcept:
 
-                with gsd.fl.open(name='file.gsd', mode='wb',
+                with gsd.fl.open(name='file.gsd', mode='wb+',
                                  application="My application",
                                  schema="My Schema", schema_version=[1,0]) as f:
                     f.write_chunk(name='chunk1',
@@ -838,7 +850,7 @@ cdef class GSDFile:
         Example:
             .. ipython:: python
 
-                with gsd.fl.open(name='file.gsd', mode='wb',
+                with gsd.fl.open(name='file.gsd', mode='wb+',
                                  application="My application",
                                  schema="My Schema", schema_version=[1,0]) as f:
                     f.write_chunk(name='data/chunk1',

--- a/gsd/fl.pyx
+++ b/gsd/fl.pyx
@@ -223,7 +223,7 @@ def open(name, mode, application=None, schema=None, schema_version=None):
 
         .. ipython:: python
 
-            with gsd.fl.open(name='file.gsd', mode='wb+',
+            with gsd.fl.open(name='file.gsd', mode='w',
                              application="My application", schema="My Schema",
                              schema_version=[1,0]) as f:
                 f.write_chunk(name='chunk1',
@@ -240,7 +240,7 @@ def open(name, mode, application=None, schema=None, schema_version=None):
                                                dtype=numpy.float32))
                 f.end_frame()
 
-            f = gsd.fl.open(name='file.gsd', mode='rb')
+            f = gsd.fl.open(name='file.gsd', mode='r')
             if f.chunk_exists(frame=0, name='chunk1'):
                 data = f.read_chunk(frame=0, name='chunk1')
             data
@@ -438,7 +438,7 @@ cdef class GSDFile:
             .. ipython:: python
                 :okexcept:
 
-                f = gsd.fl.open(name='file.gsd', mode='wb+',
+                f = gsd.fl.open(name='file.gsd', mode='w',
                                 application="My application",
                                 schema="My Schema", schema_version=[1,0])
                 f.write_chunk(name='chunk1',
@@ -469,7 +469,7 @@ cdef class GSDFile:
         Example:
             .. ipython:: python
 
-                with gsd.fl.open(name='file.gsd', mode='wb+',
+                with gsd.fl.open(name='file.gsd', mode='w',
                                  application="My application",
                                  schema="My Schema", schema_version=[1,0]) as f:
                     for i in range(10):
@@ -478,7 +478,7 @@ cdef class GSDFile:
                                                        dtype=numpy.float32))
                         f.end_frame()
 
-                f = gsd.fl.open(name='file.gsd', mode='rb+',
+                f = gsd.fl.open(name='file.gsd', mode='r+',
                                 application="My application",
                                 schema="My Schema", schema_version=[1,0])
                 f.nframes
@@ -514,7 +514,7 @@ cdef class GSDFile:
         Example:
             .. ipython:: python
 
-                f = gsd.fl.open(name='file.gsd', mode='wb+',
+                f = gsd.fl.open(name='file.gsd', mode='w',
                                 application="My application",
                                 schema="My Schema", schema_version=[1,0])
 
@@ -565,7 +565,7 @@ cdef class GSDFile:
         Example:
             .. ipython:: python
 
-                f = gsd.fl.open(name='file.gsd', mode='wb+',
+                f = gsd.fl.open(name='file.gsd', mode='w',
                                 application="My application",
                                 schema="My Schema", schema_version=[1,0])
 
@@ -674,7 +674,7 @@ cdef class GSDFile:
         Example:
             .. ipython:: python
 
-                with gsd.fl.open(name='file.gsd', mode='wb+',
+                with gsd.fl.open(name='file.gsd', mode='w',
                                  application="My application",
                                  schema="My Schema", schema_version=[1,0]) as f:
                     f.write_chunk(name='chunk1',
@@ -692,7 +692,7 @@ cdef class GSDFile:
                                                    dtype=numpy.float32))
                     f.end_frame()
 
-                f = gsd.fl.open(name='file.gsd', mode='rb',
+                f = gsd.fl.open(name='file.gsd', mode='r',
                                 application="My application",
                                 schema="My Schema", schema_version=[1,0])
 
@@ -741,7 +741,7 @@ cdef class GSDFile:
             .. ipython:: python
                 :okexcept:
 
-                with gsd.fl.open(name='file.gsd', mode='wb+',
+                with gsd.fl.open(name='file.gsd', mode='w',
                                  application="My application",
                                  schema="My Schema", schema_version=[1,0]) as f:
                     f.write_chunk(name='chunk1',
@@ -759,7 +759,7 @@ cdef class GSDFile:
                                                    dtype=numpy.float32))
                     f.end_frame()
 
-                f = gsd.fl.open(name='file.gsd', mode='rb',
+                f = gsd.fl.open(name='file.gsd', mode='r',
                                 application="My application",
                                 schema="My Schema", schema_version=[1,0])
                 f.read_chunk(frame=0, name='chunk1')
@@ -876,7 +876,7 @@ cdef class GSDFile:
         Example:
             .. ipython:: python
 
-                with gsd.fl.open(name='file.gsd', mode='wb+',
+                with gsd.fl.open(name='file.gsd', mode='w',
                                  application="My application",
                                  schema="My Schema", schema_version=[1,0]) as f:
                     f.write_chunk(name='data/chunk1',
@@ -894,7 +894,7 @@ cdef class GSDFile:
                                                    dtype=numpy.float32))
                     f.end_frame()
 
-                f = gsd.fl.open(name='file.gsd', mode='rb',
+                f = gsd.fl.open(name='file.gsd', mode='r',
                                 application="My application",
                                 schema="My Schema", schema_version=[1,0])
 
@@ -956,7 +956,7 @@ cdef class GSDFile:
 
     def __reduce__(self):
         """Allows filehandles to be pickled when in read only mode."""
-        if self.mode not in ['rb', 'rb+']:
+        if self.mode not in ['rb', 'r']:
             raise PickleError("Only read only GSDFiles can be pickled.")
         return (GSDFile,
                 (self.name, self.mode, self.application,

--- a/gsd/fl.pyx
+++ b/gsd/fl.pyx
@@ -214,9 +214,7 @@ def open(name, mode, application=None, schema=None, schema_version=None):
         +------------------+---------------------------------------------+
         | ``'xb+'``        | Equivalent to ``'x'``                       |
         +------------------+---------------------------------------------+
-        | ``'ab'``         | Open an existing file for reading and       |
-        |                  | writing. Does *not* create or overwrite     |
-        |                  | existing files.                             |
+        | ``'ab'``         | Equivalent to ``'r+'``                      |
         +------------------+---------------------------------------------+
 
     Example:

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -1114,9 +1114,7 @@ def open(name, mode='r'):
         +------------------+---------------------------------------------+
         | ``'xb+'``        | Equivalent to ``'x'``                       |
         +------------------+---------------------------------------------+
-        | ``'ab'``         | Open an existing file for reading and       |
-        |                  | writing. Does *not* create or overwrite     |
-        |                  | existing files.                             |
+        | ``'ab'``         | Equivalent to ``'r+'``                      |
         +------------------+---------------------------------------------+
     """
     if fl is None:

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -1072,43 +1072,52 @@ def open(name, mode='rb'):
         `HOOMDTrajectory` instance that accesses the file **name** with the
         given **mode**.
 
-    Valid values for mode:
+    Valid values for ``mode``:
 
     +------------------+---------------------------------------------+
     | mode             | description                                 |
     +==================+=============================================+
-    | ``'rb'``         | Open an existing file for reading.          |
+    | ``'r'``          | Open an existing file for reading.          |
     +------------------+---------------------------------------------+
-    | ``'rb+'``        | Open an existing file for reading and       |
+    | ``'r+'``         | Open an existing file for reading and       |
     |                  | writing.                                    |
     +------------------+---------------------------------------------+
-    | ``'wb'``         | Open a file for reading and writing.        |
+    | ``'w'``          | Open a file for reading and writing.        |
     |                  | Creates the file if needed, or overwrites   |
     |                  | an existing file.                           |
     +------------------+---------------------------------------------+
-    | ``'wb+'``        | Open a file for reading and writing.        |
-    |                  | Creates the file if needed, or overwrites   |
-    |                  | an existing file.                           |
-    +------------------+---------------------------------------------+
-    | ``'xb'``         | Create a gsd file exclusively and opens it  |
+    | ``'x'``          | Create a gsd file exclusively and opens it  |
     |                  | for reading and writing.                    |
     |                  | Raise :py:exc:`FileExistsError`             |
     |                  | if it already exists.                       |
     +------------------+---------------------------------------------+
-    | ``'xb+'``        | Create a gsd file exclusively and opens it  |
-    |                  | for reading and writing.                    |
-    |                  | Raise :py:exc:`FileExistsError`             |
-    |                  | if it already exists.                       |
-    +------------------+---------------------------------------------+
-    | ``'ab'``         | Open an existing file for reading and       |
-    |                  | writing. Does *not* create or overwrite     |
-    |                  | existing files.                             |
+    | ``'a'``          | Open a file for reading and writing.        |
+    |                  | Creates the file if it doesn't exist.       |
     +------------------+---------------------------------------------+
 
     .. deprecated:: 2.9.0
 
-        The following values to ``mode`` are deprecated: ``'ab'``, ``'xb'``,
-        and ``'wb'``.
+        The following values to ``mode`` are deprecated:
+
+        +------------------+---------------------------------------------+
+        | mode             | description                                 |
+        +==================+=============================================+
+        | ``'rb'``         | Equivalent to ``'r'``                       |
+        +------------------+---------------------------------------------+
+        | ``'rb+'``        | Equivalent to ``'r+'``                      |
+        +------------------+---------------------------------------------+
+        | ``'wb'``         | Equivalent to ``'w'``                       |
+        +------------------+---------------------------------------------+
+        | ``'wb+'``        | Equivalent to ``'w'``                       |
+        +------------------+---------------------------------------------+
+        | ``'xb'``         | Equivalent to ``'x'``                       |
+        +------------------+---------------------------------------------+
+        | ``'xb+'``        | Equivalent to ``'x'``                       |
+        +------------------+---------------------------------------------+
+        | ``'ab'``         | Open an existing file for reading and       |
+        |                  | writing. Does *not* create or overwrite     |
+        |                  | existing files.                             |
+        +------------------+---------------------------------------------+
     """
     if fl is None:
         raise RuntimeError("file layer module is not available")

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -1104,6 +1104,11 @@ def open(name, mode='rb'):
     |                  | writing. Does *not* create or overwrite     |
     |                  | existing files.                             |
     +------------------+---------------------------------------------+
+
+    .. deprecated:: 2.9.0
+
+        The following values to ``mode`` are deprecated: ``'ab'``, ``'xb'``,
+        and ``'wb'``.
     """
     if fl is None:
         raise RuntimeError("file layer module is not available")

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -1059,7 +1059,7 @@ class HOOMDTrajectory(object):
         self.file.close()
 
 
-def open(name, mode='rb'):
+def open(name, mode='r'):
     """Open a hoomd schema GSD file.
 
     The return value of `open` can be used as a context manager.
@@ -1172,7 +1172,7 @@ def read_log(name, scalar_only=False):
         raise RuntimeError("gsd module is not available")
 
     with fl.open(name=str(name),
-                 mode='rb',
+                 mode='r',
                  application='gsd.hoomd ' + gsd.__version__,
                  schema='hoomd',
                  schema_version=[1, 4]) as gsdfileobj:

--- a/gsd/pygsd.py
+++ b/gsd/pygsd.py
@@ -23,7 +23,7 @@ filesystem, and for writing gsd files, use :py:mod:`gsd.fl`.
 The :py:class:`GSDFile` in this module can be used with the
 :py:class:`gsd.hoomd.HOOMDTrajectory` hoomd reader:
 
->>> with gsd.pygsd.GSDFile('test.gsd', 'rb') as f:
+>>> with gsd.pygsd.GSDFile('test.gsd', 'r') as f:
 ...     t = gsd.hoomd.HOOMDTrajectory(f)
 ...     pos = t[0].particles.position
 
@@ -85,20 +85,20 @@ class GSDFile(object):
     Examples:
         Open a file in **read-only** mode::
 
-            f = GSDFile(open('file.gsd', mode='rb'))
+            f = GSDFile(open('file.gsd', mode='r'))
             if f.chunk_exists(frame=0, name='chunk'):
                 data = f.read_chunk(frame=0, name='chunk')
 
         Access file **metadata**::
 
-            f = GSDFile(open('file.gsd', mode='rb'))
+            f = GSDFile(open('file.gsd', mode='r'))
             print(f.name, f.mode, f.gsd_version)
             print(f.application, f.schema, f.schema_version)
             print(f.nframes)
 
         Use as a **context manager**::
 
-            with GSDFile(open('file.gsd', mode='rb')) as f:
+            with GSDFile(open('file.gsd', mode='r')) as f:
                 data = f.read_chunk(frame=0, name='chunk')
     """
 
@@ -269,7 +269,7 @@ class GSDFile(object):
 
             Handle non-existent chunks::
 
-                with GSDFile(open('file.gsd', mode='rb')) as f:
+                with GSDFile(open('file.gsd', mode='r')) as f:
                     if f.chunk_exists(frame=0, name='chunk'):
                         return f.read_chunk(frame=0, name='chunk')
                     else:
@@ -294,19 +294,19 @@ class GSDFile(object):
         Examples:
             Read a 1D array::
 
-                with GSDFile(name=filename, mode='rb') as f:
+                with GSDFile(name=filename, mode='r') as f:
                     data = f.read_chunk(frame=0, name='chunk1d')
                     # data.shape == [N]
 
             Read a 2D array::
 
-                with GSDFile(name=filename, mode='rb') as f:
+                with GSDFile(name=filename, mode='r') as f:
                     data = f.read_chunk(frame=0, name='chunk2d')
                     # data.shape == [N,M]
 
             Read multiple frames::
 
-                with GSDFile(name=filename, mode='rb') as f:
+                with GSDFile(name=filename, mode='r') as f:
                     data0 = f.read_chunk(frame=0, name='chunk')
                     data1 = f.read_chunk(frame=1, name='chunk')
                     data2 = f.read_chunk(frame=2, name='chunk')
@@ -397,7 +397,7 @@ class GSDFile(object):
     @property
     def mode(self):
         """str: Mode of the open file."""
-        return 'rb'
+        return 'r'
 
     @property
     def gsd_version(self):

--- a/gsd/test/conftest.py
+++ b/gsd/test/conftest.py
@@ -7,7 +7,7 @@ import pytest
 import collections
 
 Mode = collections.namedtuple('Mode', 'read write')
-mode_list = [Mode('rb', 'wb'), Mode('rb+', 'wb+')]
+mode_list = [Mode('r', 'w'), Mode('a', 'x'), Mode('r', 'a')]
 
 
 def open_mode_name(mode):

--- a/gsd/test/test_fl.py
+++ b/gsd/test/test_fl.py
@@ -166,8 +166,7 @@ def test_append(tmp_path, open_mode):
 
     # test again with pygsd
     with gsd.pygsd.GSDFile(
-            file=open(str(tmp_path
-                          / 'test_append.gsd'), mode='rb')) as f:
+            file=open(str(tmp_path / 'test_append.gsd'), mode='rb')) as f:
         assert f.nframes == nframes
         for i in range(nframes):
             data1 = f.read_chunk(frame=i, name='data1')
@@ -883,9 +882,8 @@ def test_zero_size(tmp_path, open_mode):
         assert data_read.dtype == numpy.float32
 
     # test again with pygsd
-    with gsd.pygsd.GSDFile(
-            file=open(str(tmp_path
-                          / 'test_zero.gsd'), mode='rb')) as f:
+    with gsd.pygsd.GSDFile(file=open(str(tmp_path
+                                         / 'test_zero.gsd'), mode='rb')) as f:
         assert f.nframes == 1
         data_read = f.read_chunk(frame=0, name='data')
         assert data_read.shape == (0,)

--- a/gsd/test/test_fl.py
+++ b/gsd/test/test_fl.py
@@ -315,7 +315,7 @@ def test_dtype_errors(tmp_path, open_mode):
     with pytest.raises(Exception):
         data = numpy.array([1, 2, 3, 4, 5, 10012], dtype=numpy.bool_)
 
-        with gsd.fl.open(name=tmp_path / 'test_dtype_errors.gsd',
+        with gsd.fl.open(name=tmp_path / 'test_dtype_errors1.gsd',
                          mode=open_mode.write,
                          application='test_dtype_errors',
                          schema='none',
@@ -326,7 +326,7 @@ def test_dtype_errors(tmp_path, open_mode):
     with pytest.raises(Exception):
         data = numpy.array([1, 2, 3, 4, 5, 10012], dtype=numpy.float16)
 
-        with gsd.fl.open(name=tmp_path / 'test_dtype_errors.gsd',
+        with gsd.fl.open(name=tmp_path / 'test_dtype_errors2.gsd',
                          mode=open_mode.write,
                          application='test_dtype_errors',
                          schema='none',
@@ -337,7 +337,7 @@ def test_dtype_errors(tmp_path, open_mode):
     with pytest.raises(Exception):
         data = numpy.array([1, 2, 3, 4, 5, 10012], dtype=numpy.complex64)
 
-        with gsd.fl.open(name=tmp_path / 'test_dtype_errors.gsd',
+        with gsd.fl.open(name=tmp_path / 'test_dtype_errors3.gsd',
                          mode=open_mode.write,
                          application='test_dtype_errors',
                          schema='none',
@@ -348,7 +348,7 @@ def test_dtype_errors(tmp_path, open_mode):
     with pytest.raises(Exception):
         data = numpy.array([1, 2, 3, 4, 5, 10012], dtype=numpy.complex128)
 
-        with gsd.fl.open(name=tmp_path / 'test_dtype_errors.gsd',
+        with gsd.fl.open(name=tmp_path / 'test_dtype_errors4.gsd',
                          mode=open_mode.write,
                          application='test_dtype_errors',
                          schema='none',

--- a/gsd/test/test_fl.py
+++ b/gsd/test/test_fl.py
@@ -17,9 +17,9 @@ import sys
 test_path = pathlib.Path(os.path.realpath(__file__)).parent
 
 
-def test_create(tmp_path):
+def test_create(tmp_path, open_mode):
     """Test creation of GSD files."""
-    gsd.fl.open(mode='xb',
+    gsd.fl.open(mode=open_mode.write,
                 name=tmp_path / "test_create.gsd",
                 application="test_create",
                 schema="none",
@@ -44,14 +44,14 @@ def test_dtype(tmp_path, typ):
     data2d = numpy.array([[10, 20], [30, 40], [50, 80]], dtype=typ)
     data_zero = numpy.array([], dtype=typ)
 
-    gsd.fl.open(mode='xb',
+    gsd.fl.open(mode='x',
                 name=tmp_path / "test_dtype.gsd",
                 application="test_dtype",
                 schema="none",
                 schema_version=[1, 2])
 
     with gsd.fl.open(name=tmp_path / "test_dtype.gsd",
-                     mode='wb',
+                     mode='w',
                      application="test_dtype",
                      schema="none",
                      schema_version=[1, 2]) as f:
@@ -61,7 +61,7 @@ def test_dtype(tmp_path, typ):
         f.end_frame()
 
     with gsd.fl.open(name=tmp_path / "test_dtype.gsd",
-                     mode='rb',
+                     mode='r',
                      application="test_dtype",
                      schema="none",
                      schema_version=[1, 2]) as f:
@@ -119,7 +119,7 @@ def test_metadata(tmp_path, open_mode):
     with gsd.pygsd.GSDFile(
             file=open(str(tmp_path / 'test_metadata.gsd'), mode='rb')) as f:
         assert f.name == str(tmp_path / 'test_metadata.gsd')
-        assert f.mode == 'rb'
+        assert f.mode == 'r'
         assert f.application == 'test_metadata'
         assert f.schema == 'none'
         assert f.schema_version == (1, 2)
@@ -140,11 +140,11 @@ def test_append(tmp_path, open_mode):
     nframes = 1024
 
     with gsd.fl.open(name=tmp_path / 'test_append.gsd',
-                     mode='ab',
+                     mode='a',
                      application='test_append',
                      schema='none',
                      schema_version=[1, 2]) as f:
-        assert f.mode == 'ab'
+        assert f.mode == 'a'
         for i in range(nframes):
             data[0] = i
             f.write_chunk(name='data1', data=data)
@@ -167,7 +167,7 @@ def test_append(tmp_path, open_mode):
     # test again with pygsd
     with gsd.pygsd.GSDFile(
             file=open(str(tmp_path
-                          / 'test_append.gsd'), mode=open_mode.read)) as f:
+                          / 'test_append.gsd'), mode='rb')) as f:
         assert f.nframes == nframes
         for i in range(nframes):
             data1 = f.read_chunk(frame=i, name='data1')
@@ -268,7 +268,7 @@ def test_readonly_errors(tmp_path, open_mode):
 
     data = numpy.array([1, 2, 3, 4, 5, 10012], dtype=numpy.int64)
     with gsd.fl.open(name=tmp_path / 'test_readonly_errors.gsd',
-                     mode='rb',
+                     mode='r',
                      application='test_readonly_errors',
                      schema='none',
                      schema_version=[1, 2]) as f:
@@ -299,8 +299,7 @@ def test_fileio_errors(tmp_path, open_mode):
                         schema='none',
                         schema_version=[1, 2])
 
-        with open(str(tmp_path / 'test_fileio_errors.gsd'),
-                  open_mode.write) as f:
+        with open(str(tmp_path / 'test_fileio_errors.gsd'), 'wb') as f:
             f.write(b'test')
 
         with pytest.raises(RuntimeError):
@@ -363,11 +362,11 @@ def test_truncate(tmp_path):
     data = numpy.ascontiguousarray(numpy.random.random(size=(1000, 3)),
                                    dtype=numpy.float32)
     with gsd.fl.open(name=tmp_path / 'test_truncate.gsd',
-                     mode='wb',
+                     mode='w',
                      application='test_truncate',
                      schema='none',
                      schema_version=[1, 2]) as f:
-        assert f.mode == 'wb'
+        assert f.mode == 'w'
         for i in range(10):
             f.write_chunk(name='data', data=data)
             f.end_frame()
@@ -384,12 +383,12 @@ def test_truncate(tmp_path):
         f.end_frame()
 
     with gsd.fl.open(name=tmp_path / 'test_truncate.gsd',
-                     mode='rb',
+                     mode='r',
                      application='test_truncate',
                      schema='none',
                      schema_version=[1, 2]) as f:
         assert f.name == str(tmp_path / 'test_truncate.gsd')
-        assert f.mode == 'rb'
+        assert f.mode == 'r'
         assert f.application == 'test_truncate'
         assert f.schema == 'none'
         assert f.schema_version == (1, 2)
@@ -434,7 +433,7 @@ def test_open(tmp_path):
     data = numpy.array([1, 2, 3, 4, 5, 10012], dtype=numpy.int64)
 
     with gsd.fl.open(name=tmp_path / 'test.gsd',
-                     mode='xb',
+                     mode='x',
                      application='test_open',
                      schema='none',
                      schema_version=[1, 2]) as f:
@@ -442,7 +441,7 @@ def test_open(tmp_path):
         f.end_frame()
 
     with gsd.fl.open(name=tmp_path / 'test_2.gsd',
-                     mode='xb+',
+                     mode='x',
                      application='test_open',
                      schema='none',
                      schema_version=[1, 2]) as f:
@@ -451,7 +450,7 @@ def test_open(tmp_path):
         f.read_chunk(0, name='chunk1')
 
     with gsd.fl.open(name=tmp_path / 'test.gsd',
-                     mode='wb',
+                     mode='w',
                      application='test_open',
                      schema='none',
                      schema_version=[1, 2]) as f:
@@ -459,7 +458,7 @@ def test_open(tmp_path):
         f.end_frame()
 
     with gsd.fl.open(name=tmp_path / 'test.gsd',
-                     mode='wb+',
+                     mode='w',
                      application='test_open',
                      schema='none',
                      schema_version=[1, 2]) as f:
@@ -468,7 +467,7 @@ def test_open(tmp_path):
         f.read_chunk(0, name='chunk1')
 
     with gsd.fl.open(name=tmp_path / 'test.gsd',
-                     mode='ab',
+                     mode='a',
                      application='test_open',
                      schema='none',
                      schema_version=[1, 2]) as f:
@@ -476,7 +475,7 @@ def test_open(tmp_path):
         f.end_frame()
 
     with gsd.fl.open(name=tmp_path / 'test.gsd',
-                     mode='rb',
+                     mode='r',
                      application='test_open',
                      schema='none',
                      schema_version=[1, 2]) as f:
@@ -484,7 +483,7 @@ def test_open(tmp_path):
         f.read_chunk(1, name='chunk1')
 
     with gsd.fl.open(name=tmp_path / 'test.gsd',
-                     mode='rb+',
+                     mode='r+',
                      application='test_open',
                      schema='none',
                      schema_version=[1, 2]) as f:
@@ -635,7 +634,7 @@ def test_gsd_v1_read():
 
     # test with the C implemantation
     with gsd.fl.open(name=test_path / 'test_gsd_v1.gsd',
-                     mode='rb',
+                     mode='r',
                      application='test_gsd_v1',
                      schema='none',
                      schema_version=[1, 2]) as f:
@@ -675,7 +674,7 @@ def test_gsd_v1_upgrade_read(tmp_path, open_mode):
     shutil.copy(test_path / 'test_gsd_v1.gsd', tmp_path / 'test_gsd_v1.gsd')
 
     with gsd.fl.open(name=tmp_path / 'test_gsd_v1.gsd',
-                     mode='rb+',
+                     mode='r+',
                      application='test_gsd_v1',
                      schema='none',
                      schema_version=[1, 2]) as f:
@@ -750,7 +749,7 @@ def test_gsd_v1_write(tmp_path, open_mode):
 
     # test that we can write new entries to the file
     with gsd.fl.open(name=tmp_path / 'test_gsd_v1.gsd',
-                     mode='rb+',
+                     mode='r+',
                      application='test_gsd_v1',
                      schema='none',
                      schema_version=[1, 2]) as f:
@@ -819,7 +818,7 @@ def test_gsd_v1_upgrade_write(tmp_path, open_mode):
 
     # test that we can write new entries to the file
     with gsd.fl.open(name=tmp_path / 'test_gsd_v1.gsd',
-                     mode='rb+',
+                     mode='r+',
                      application='test_gsd_v1',
                      schema='none',
                      schema_version=[1, 2]) as f:
@@ -886,7 +885,7 @@ def test_zero_size(tmp_path, open_mode):
     # test again with pygsd
     with gsd.pygsd.GSDFile(
             file=open(str(tmp_path
-                          / 'test_zero.gsd'), mode=open_mode.read)) as f:
+                          / 'test_zero.gsd'), mode='rb')) as f:
         assert f.nframes == 1
         data_read = f.read_chunk(frame=0, name='data')
         assert data_read.shape == (0,)
@@ -902,7 +901,7 @@ def test_utf8(tmp_path):
     fname = '中文.gsd'
 
     with gsd.fl.open(name=tmp_path / fname,
-                     mode='xb',
+                     mode='x',
                      application='test_open',
                      schema='none',
                      schema_version=[1, 2]) as f:
@@ -914,7 +913,7 @@ def test_utf8(tmp_path):
     assert fname in dir_list
 
     with gsd.fl.open(name=tmp_path / fname,
-                     mode='wb',
+                     mode='w',
                      application='test_open',
                      schema='none',
                      schema_version=[1, 2]) as f:
@@ -922,19 +921,19 @@ def test_utf8(tmp_path):
         f.end_frame()
 
     with gsd.fl.open(name=tmp_path / fname,
-                     mode='rb',
+                     mode='r',
                      application='test_open',
                      schema='none',
                      schema_version=[1, 2]) as f:
         f.read_chunk(0, name='chunk1')
 
 
-@pytest.mark.parametrize('mode', ['wb', 'wb+', 'ab', 'rb+', 'xb', 'xb+'])
+@pytest.mark.parametrize('mode', ['w', 'x', 'a', 'r+'])
 def test_read_write(tmp_path, mode):
     """Test that data chunks can read from files opened in all write modes."""
     if mode[0] == 'r' or mode[0] == 'a':
         with gsd.fl.open(name=tmp_path / 'test_read_write.gsd',
-                         mode='wb',
+                         mode='w',
                          application='test_read_write',
                          schema='none',
                          schema_version=[1, 2]):

--- a/gsd/test/test_hoomd.py
+++ b/gsd/test/test_hoomd.py
@@ -12,7 +12,7 @@ import pytest
 
 def test_create(tmp_path):
     """Test that gsd files can be created."""
-    with gsd.hoomd.open(name=tmp_path / "test_create.gsd", mode='wb') as hf:
+    with gsd.hoomd.open(name=tmp_path / "test_create.gsd", mode='w') as hf:
         assert hf.file.schema == 'hoomd'
         assert hf.file.schema_version >= (1, 0)
 
@@ -670,7 +670,7 @@ def test_view_slicing_and_iteration(tmp_path, open_mode):
 
 def test_truncate(tmp_path):
     """Test the truncate API."""
-    with gsd.hoomd.open(name=tmp_path / "test_iteration.gsd", mode='wb') as hf:
+    with gsd.hoomd.open(name=tmp_path / "test_iteration.gsd", mode='w') as hf:
         hf.extend((create_frame(i) for i in range(20)))
 
         assert len(hf) == 20
@@ -766,15 +766,15 @@ def test_log(tmp_path, open_mode):
                                          frame1.log['value/pressure'])
 
 
-def test_pickle(tmp_path, open_mode):
+def test_pickle(tmp_path):
     """Test that hoomd trajectory objects can be pickled."""
     with gsd.hoomd.open(name=tmp_path / "test_pickling.gsd",
-                        mode=open_mode.write) as traj:
+                        mode='w') as traj:
         traj.extend((create_frame(i) for i in range(20)))
         with pytest.raises(pickle.PickleError):
             pkl = pickle.dumps(traj)
     with gsd.hoomd.open(name=tmp_path / "test_pickling.gsd",
-                        mode=open_mode.read) as traj:
+                        mode='r') as traj:
         pkl = pickle.dumps(traj)
         with pickle.loads(pkl) as hf:
             assert len(hf) == 20
@@ -785,7 +785,7 @@ def test_pickle(tmp_path, open_mode):
     ['particles', 'bonds', 'angles', 'dihedrals', 'impropers', 'pairs'])
 def test_no_duplicate_types(tmp_path, container):
     """Test that duplicate types raise an error."""
-    with gsd.hoomd.open(name=tmp_path / "test_create.gsd", mode='wb') as hf:
+    with gsd.hoomd.open(name=tmp_path / "test_create.gsd", mode='w') as hf:
 
         frame = gsd.hoomd.Frame()
 
@@ -819,7 +819,7 @@ def test_read_log(tmp_path):
     ]
     frame1.log['value/pressure'] = [5]
 
-    with gsd.hoomd.open(name=tmp_path / "test_log.gsd", mode='wb') as hf:
+    with gsd.hoomd.open(name=tmp_path / "test_log.gsd", mode='w') as hf:
         hf.extend([frame0, frame1])
 
     # Test scalar_only = False
@@ -877,7 +877,7 @@ def test_read_log_warning(tmp_path):
     """Test that read_log issues a warning."""
     frame = gsd.hoomd.Frame()
 
-    with gsd.hoomd.open(name=tmp_path / "test_log.gsd", mode='wb') as hf:
+    with gsd.hoomd.open(name=tmp_path / "test_log.gsd", mode='w') as hf:
         hf.extend([frame])
 
     with pytest.warns(RuntimeWarning):

--- a/gsd/test/test_hoomd.py
+++ b/gsd/test/test_hoomd.py
@@ -768,13 +768,11 @@ def test_log(tmp_path, open_mode):
 
 def test_pickle(tmp_path):
     """Test that hoomd trajectory objects can be pickled."""
-    with gsd.hoomd.open(name=tmp_path / "test_pickling.gsd",
-                        mode='w') as traj:
+    with gsd.hoomd.open(name=tmp_path / "test_pickling.gsd", mode='w') as traj:
         traj.extend((create_frame(i) for i in range(20)))
         with pytest.raises(pickle.PickleError):
             pkl = pickle.dumps(traj)
-    with gsd.hoomd.open(name=tmp_path / "test_pickling.gsd",
-                        mode='r') as traj:
+    with gsd.hoomd.open(name=tmp_path / "test_pickling.gsd", mode='r') as traj:
         pkl = pickle.dumps(traj)
         with pickle.loads(pkl) as hf:
             assert len(hf) == 20

--- a/gsd/test/test_largefile.py
+++ b/gsd/test/test_largefile.py
@@ -17,7 +17,7 @@ def test_large_n(tmp_path, N):
 
     data = numpy.linspace(0, N, num=N, endpoint=False, dtype=numpy.uint32)
     with gsd.fl.open(name=tmp_path / 'test_large_N.gsd',
-                     mode='xb',
+                     mode='x',
                      application='test_large_N',
                      schema='none',
                      schema_version=[1, 2]) as f:
@@ -25,7 +25,7 @@ def test_large_n(tmp_path, N):
         f.end_frame()
 
     with gsd.fl.open(name=tmp_path / 'test_large_N.gsd',
-                     mode='rb',
+                     mode='r',
                      application='test_large_N',
                      schema='none',
                      schema_version=[1, 2]) as f:

--- a/scripts/benchmark-hoomd.py
+++ b/scripts/benchmark-hoomd.py
@@ -115,13 +115,11 @@ def run_benchmarks(N, size):
 
     # if the file size is small, write it once to warm up the disk
     if size < 64 * 1024**3:
-        gsd.hoomd.open(mode='wb', name='test.gsd')
-        with gsd.hoomd.open(name='test.gsd', mode='wb') as hf:
+        with gsd.hoomd.open(name='test.gsd', mode='w') as hf:
             write_file(hf, nframes, N, position, orientation)
 
     # write it again and time this one
-    gsd.hoomd.open(mode='wb', name='test.gsd')
-    with gsd.hoomd.open(name='test.gsd', mode='wb') as hf:
+    with gsd.hoomd.open(name='test.gsd', mode='w') as hf:
         start = time.time()
         write_file(hf, nframes, N, position, orientation)
 
@@ -136,7 +134,7 @@ def run_benchmarks(N, size):
     # time how long it takes to open the file
     print("Opening file... ", file=sys.stderr, flush=True, end='')
     start = time.time()
-    with gsd.hoomd.open(name='test.gsd', mode='rb') as hf:
+    with gsd.hoomd.open(name='test.gsd', mode='r') as hf:
         end = time.time()
 
         print(end - start, "s", file=sys.stderr, flush=True)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Base backwards compatible bug fixes on `trunk-patch`. -->
<!-- Base additional functionality on `trunk-minor`. -->
<!-- Base API incompatible changes on `trunk-major`. -->

## Description

<!-- Describe your changes in detail. -->
Add file modes that mimic those in **h5py**.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
GSD files must read the header and indices in order to write to the file, and files must be open in binary mode. Adopting the simplified set of file modes from **h5py** will make it easier for users to choose the correct mode. Work on #236 prompted this change, as the existence of the `GSD_APPEND` mode resulted in several bugs during development.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Existing unit tests pass and provide the expected `FutureWarning` messages.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added:

* File modes ``'r'``, ``'r+'``, ``'w'``, ``'x'``, and ``'a'``.
  (`#238 <https://github.com/glotzerlab/gsd/pull/238>`__).

Deprecated:

* File modes ``'wb'``, ``'wb+'``, ``'rb'``,  ``'rb+'``, ``'ab'``, ``'xb'``, and ``'xb+'``.  
  (`#238 <https://github.com/glotzerlab/gsd/pull/238>`__).
* [C API] ``GSD_APPEND`` file open mode.
  (`#238 <https://github.com/glotzerlab/gsd/pull/238>`__).
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.