### PR TITLE
Add HOOMDTrajectory.flush

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,13 @@ Change Log
 3.x
 ---
 
+3.1.0 (2023-07-??)
+^^^^^^^^^^^^^^^^^^
+
+*Added:*
+
+* ``HOOMDTrajectory.flush`` - flush buffered writes on an open ``HOOMDTrajectory``.
+
 3.0.1 (2023-06-20)
 ^^^^^^^^^^^^^^^^^^
 

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -1036,6 +1036,10 @@ class HOOMDTrajectory(object):
         """Close the file when the context manager exits."""
         self.file.close()
 
+    def flush(self):
+        """Flush all buffered frames to the file."""
+        self._file.flush()
+
 
 def open(name, mode='r'):
     """Open a hoomd schema GSD file.

--- a/gsd/test/test_hoomd.py
+++ b/gsd/test/test_hoomd.py
@@ -32,13 +32,13 @@ def test_append(tmp_path, open_mode):
                         mode=open_mode.read) as hf:
         assert len(hf) == 5
 
+
 def test_flush(tmp_path, open_mode):
     """Test that HOOMTrajectory objects flush buffered writes."""
     frame = gsd.hoomd.Frame()
     frame.particles.N = 10
 
-    hf = gsd.hoomd.open(name=tmp_path / "test_append.gsd",
-                        mode=open_mode.write)
+    hf = gsd.hoomd.open(name=tmp_path / "test_append.gsd", mode=open_mode.write)
     for i in range(5):
         frame.configuration.step = i + 1
         hf.append(frame)
@@ -48,6 +48,7 @@ def test_flush(tmp_path, open_mode):
     with gsd.hoomd.open(name=tmp_path / "test_append.gsd",
                         mode=open_mode.read) as hf:
         assert len(hf) == 5
+
 
 def create_frame(i):
     """Helper function to create frame objects."""

--- a/gsd/test/test_hoomd.py
+++ b/gsd/test/test_hoomd.py
@@ -32,6 +32,22 @@ def test_append(tmp_path, open_mode):
                         mode=open_mode.read) as hf:
         assert len(hf) == 5
 
+def test_flush(tmp_path, open_mode):
+    """Test that HOOMTrajectory objects flush buffered writes."""
+    frame = gsd.hoomd.Frame()
+    frame.particles.N = 10
+
+    hf = gsd.hoomd.open(name=tmp_path / "test_append.gsd",
+                        mode=open_mode.write)
+    for i in range(5):
+        frame.configuration.step = i + 1
+        hf.append(frame)
+
+    hf.flush()
+
+    with gsd.hoomd.open(name=tmp_path / "test_append.gsd",
+                        mode=open_mode.read) as hf:
+        assert len(hf) == 5
 
 def create_frame(i):
     """Helper function to create frame objects."""


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Base backwards compatible bug fixes on `trunk-patch`. -->
<!-- Base additional functionality on `trunk-minor`. -->
<!-- Base API incompatible changes on `trunk-major`. -->

## Description

<!-- Describe your changes in detail. -->
Add the `HOOMDTrajectory.flush` method.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Provide users with a convenience method so they can flush open hoomd "files":
```
f = gsd.hoomd.open(name='file.gsd', mode='w')
f.flush()
```

Previously, this was possible only via the file handle:
```
f.file.flush()
```

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #259.

## How Has This Been Tested?

I added a unit test. The test fails `flush()` is not called.

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
- [x] I have added a change log entry to ``CHANGELOG.rst``.
