### PR TITLE
Prevent deprecation warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,13 @@ Change Log
 3.x
 ---
 
+3.1.0 (2023-07-??)
+^^^^^^^^^^^^^^^^^^
+
+*Fixed:*
+
+* ``hoomd.read_log`` no longer triggers a numpy deprecation warning.
+
 3.0.1 (2023-06-20)
 ^^^^^^^^^^^^^^^^^^
 

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -1165,7 +1165,10 @@ def read_log(name, scalar_only=False):
                 for log in logged_data_dict.keys():
                     if not gsdfileobj.chunk_exists(frame=idx, name=log):
                         continue
-                    logged_data_dict[log][idx] = gsdfileobj.read_chunk(
-                        frame=idx, name=log)
+                    data = gsdfileobj.read_chunk(frame=idx, name=log)
+                    if len(logged_data_dict[log][idx].shape) == 0:
+                        logged_data_dict[log][idx] = data[0]
+                    else:
+                        logged_data_dict[log][idx] = data
 
     return logged_data_dict


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Base backwards compatible bug fixes on `trunk-patch`. -->
<!-- Base additional functionality on `trunk-minor`. -->
<!-- Base API incompatible changes on `trunk-major`. -->

## Description

<!-- Describe your changes in detail. -->
Manually unpack scalar quantities from numpy arrays.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This prevents the following deprecation warning:
```
gsd/test/test_hoomd.py: 10 warnings
  /Users/joaander/build/gsd/gsd/hoomd.py:1170: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure 
you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)                                                            
    logged_data_dict[log][idx] = data 
```

## How Has This Been Tested?

I executed the tests locally and no longer observe the warning:
```
(venv) cheme-walker:~/build/gsd ▶ pytest gsd
======================================================================= test session starts ========================================================================
platform darwin -- Python 3.11.4, pytest-7.3.2, pluggy-1.0.0
rootdir: /Users/joaander/build/gsd
plugins: anyio-3.6.2
collected 125 items                                                                                                                                                

gsd/test/test_fl.py ..............................................................................                                                           [ 62%]
gsd/test/test_hoomd.py ............................................                                                                                          [ 97%]
gsd/test/test_largefile.py sss                                                                                                                               [100%]

================================================================== 122 passed, 3 skipped in 2.00s ==================================================================
(venv) cheme-walker:~/build/gsd ▶
```

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
- [x] I have added a change log entry to ``CHANGELOG.rst``.
