### PR TITLE
Better error handling for GSD_IO_ERRORs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,13 @@ Change Log
 3.x
 ---
 
+3.1.1 (2023-??-??)
+^^^^^^^^^^^^^^^^^^
+
+*Fixed:*
+
+* Raise a ``FileExistsError`` when opening a file that already exists with ``mode = 'x'``
+
 3.1.0 (2023-07-28)
 ^^^^^^^^^^^^^^^^^^
 

--- a/doc/credits.rst
+++ b/doc/credits.rst
@@ -17,3 +17,4 @@ The following people contributed to GSD.
 * Arthur Zamarin, Gentoo Linux
 * Alexander Stukowski, OVITO GmbH
 * Charlotte Shiqi Zhao, University of Michigan
+* Tim Moore, University of Michigan

--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -1623,7 +1623,10 @@ int gsd_create(const char* fname,
                            O_RDWR | O_CREAT | O_TRUNC | extra_flags,
                            S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
     int retval = gsd_initialize_file(fd, application, schema, schema_version);
-    close(fd);
+    if (fd != -1)
+        {
+        close(fd);
+        }
     return retval;
     }
 
@@ -1670,14 +1673,20 @@ int gsd_create_and_open(struct gsd_handle* handle,
     int retval = gsd_initialize_file(handle->fd, application, schema, schema_version);
     if (retval != 0)
         {
-        close(handle->fd);
+        if (handle->fd != -1)
+            {
+            close(handle->fd);
+            }
         return retval;
         }
 
     retval = gsd_initialize_handle(handle);
     if (retval != 0)
         {
-        close(handle->fd);
+        if (handle->fd != -1)
+            {
+            close(handle->fd);
+            }
         }
     return retval;
     }
@@ -1712,7 +1721,10 @@ int gsd_open(struct gsd_handle* handle, const char* fname, const enum gsd_open_f
     int retval = gsd_initialize_handle(handle);
     if (retval != 0)
         {
-        close(handle->fd);
+        if (handle->fd != -1)
+            {
+            close(handle->fd);
+            }
         }
     return retval;
     }

--- a/gsd/test/test_fl.py
+++ b/gsd/test/test_fl.py
@@ -1039,5 +1039,5 @@ def test_file_exists_error():
                          mode='x',
                          application='test_gsd_v1',
                          schema='none',
-                         schema_version=[1, 2]) as f:
+                         schema_version=[1, 2]):
             pass

--- a/gsd/test/test_fl.py
+++ b/gsd/test/test_fl.py
@@ -1030,3 +1030,14 @@ def test_index_entries_to_buffer(tmp_path, open_mode):
 
         with pytest.raises(RuntimeError):
             f.index_entries_to_buffer = 0
+
+
+def test_file_exists_error():
+    """Test that IO errors throw the correct Python Excetion."""
+    with pytest.raises(FileExistsError):
+        with gsd.fl.open(name=test_path / 'test_gsd_v1.gsd',
+                         mode='x',
+                         application='test_gsd_v1',
+                         schema='none',
+                         schema_version=[1, 2]) as f:
+            pass


### PR DESCRIPTION
## Description

Only call `close()` when files are opened without error so that `errno` still contains the correct error code, which allows Python to throw the correct Exception.

## Motivation and Context

Resolves #270 

## How Has This Been Tested?

Added a test that opens a file with `mode = 'x'` and asserts that a `FileExistsError` is raised.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
- [x] I have added a change log entry to ``CHANGELOG.rst``.
