### PR TITLE
Maintain all pending index entries.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Change Log
 
 *Fixed:*
 
+* Write all pending index entries to the file when `gsd_flush()` is called after `gsd_write_chunk()`
+  and before `gsd_end_frame()` (`#319 <https://github.com/glotzerlab/gsd/pull/319>`__).
 * Readthedocs builds with pandas 2.2.0
   (`#322 <https://github.com/glotzerlab/gsd/pull/322>`__).
 

--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -2012,7 +2012,7 @@ int gsd_flush(struct gsd_handle* handle)
                 {
                 handle->frame_index.data[i]
                     = handle->frame_index
-                          .data[handle->frame_index.size - handle->pending_index_entries];
+                          .data[handle->frame_index.size - handle->pending_index_entries + i];
                 }
             }
 

--- a/gsd/test/test_fl.py
+++ b/gsd/test/test_fl.py
@@ -1150,8 +1150,13 @@ def test_file_exists_error():
 
 def test_pending_index_entries(tmp_path):
     """Ensure that gsd preserves pending index entries."""
-    with gsd.fl.open(tmp_path / 'test_pending_index_entries.gsd', 'w', application="My application",
-                     schema="My Schema", schema_version=[1,0]) as f:
+    with gsd.fl.open(
+        tmp_path / 'test_pending_index_entries.gsd',
+        'w',
+        application='My application',
+        schema='My Schema',
+        schema_version=[1, 0],
+    ) as f:
         # Frame 0 must be complete to trigger the bug.
         f.write_chunk(name='0', data=numpy.array([0]))
         f.end_frame()


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Base backwards compatible bug fixes on `trunk-patch`. -->
<!-- Base additional functionality on `trunk-minor`. -->
<!-- Base API incompatible changes on `trunk-major`. -->

## Description

<!-- Describe your changes in detail. -->
Fix a bug that lost index entries in some very specific corner cases.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Whenever `gsd_flush` is called after `write_chunk` but before `end_frame`, it kept one of the pending entries and repeated it N times instead of keeping all N pending entries.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

The added unit test checks that the bug is fixed.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
- [x] I have added a change log entry to ``CHANGELOG.rst``.
