### PR TITLE
Fix the rtd builds.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     open-pull-requests-limit: 1
 
   - package-ecosystem: "pip"
-    directory: ".github"
+    directory: "/"
     target-branch: trunk-patch
     schedule:
       interval: "weekly"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Change Log
 3.2.1 (not yet released)
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
+*Fixed:*
+
+* Readthedocs builds with pandas 2.2.0
+  (`#322 <https://github.com/glotzerlab/gsd/pull/322>`__).
+
 *Changed:*
 
 * Provide support via GitHub discussions

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,8 +1,8 @@
-breathe
-cython
-furo
-ipython
-numpy
-pandas
-pyarrow
+breathe == 4.35.0
+cython == 3.0.8
+furo == 2023.9.10
+ipython == 8.20.0
+numpy == 1.26.3
+pandas == 2.2.0
+pyarrow == 15.0.0
 sphinx

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,4 +4,5 @@ furo
 ipython
 numpy
 pandas
+pyarrow
 sphinx


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Base backwards compatible bug fixes on `trunk-patch`. -->
<!-- Base additional functionality on `trunk-minor`. -->
<!-- Base API incompatible changes on `trunk-major`. -->

## Description

<!-- Describe your changes in detail. -->
Add pyarrow in rtd build.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The latest version of pandas issues a deprecation warning when building the docs.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->
Will check the rtd builds.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
- [x] I have added a change log entry to ``CHANGELOG.rst``.
