### PR TITLE
Allow users to modify returned frames.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Change Log
   (`#322 <https://github.com/glotzerlab/gsd/pull/322>`__).
 * Import without seg fault when built with CMake on macOS.
   (`#323 <https://github.com/glotzerlab/gsd/pull/323>`__).
+* Internal cached data remains valid when users modify frames obtained by indexing trajectories
+  (`#324 <https://github.com/glotzerlab/gsd/pull/324>`__).
 
 *Changed:*
 

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -901,7 +901,9 @@ class HOOMDTrajectory:
         elif self._initial_frame is not None:
             frame.configuration.box = copy.copy(self._initial_frame.configuration.box)
         else:
-            frame.configuration.box = copy.copy(frame.configuration._default_value['box'])
+            frame.configuration.box = copy.copy(
+                frame.configuration._default_value['box']
+            )
 
         # then read all groups that have N, types, etc...
         for path in [
@@ -946,9 +948,13 @@ class HOOMDTrajectory:
                         json.loads(json_string.decode('UTF-8')) for json_string in tmp
                     )
                 elif self._initial_frame is not None:
-                    container.type_shapes = copy.copy(initial_frame_container.type_shapes)
+                    container.type_shapes = copy.copy(
+                        initial_frame_container.type_shapes
+                    )
                 else:
-                    container.type_shapes = copy.copy(container._default_value['type_shapes'])
+                    container.type_shapes = copy.copy(
+                        container._default_value['type_shapes']
+                    )
 
             for name in container._default_value:
                 if name in ('N', 'types', 'type_shapes'):

--- a/gsd/test/test_hoomd.py
+++ b/gsd/test/test_hoomd.py
@@ -960,8 +960,12 @@ def test_read_log_warning(tmp_path):
 
     assert list(log.keys()) == ['configuration/step']
 
+
 def test_initial_frame_copy(tmp_path, open_mode):
-    with gsd.hoomd.open(name=tmp_path / 'test_initial_frame_copy.gsd', mode=open_mode.write) as hf:
+    """Ensure that the user does not unintentionally modify _initial_frame."""
+    with gsd.hoomd.open(
+        name=tmp_path / 'test_initial_frame_copy.gsd', mode=open_mode.write
+    ) as hf:
         frame = make_nondefault_frame()
 
         hf.append(frame)
@@ -970,7 +974,9 @@ def test_initial_frame_copy(tmp_path, open_mode):
         del frame.log['value']
         hf.append(frame)
 
-    with gsd.hoomd.open(name=tmp_path / 'test_initial_frame_copy.gsd', mode=open_mode.read) as hf:
+    with gsd.hoomd.open(
+        name=tmp_path / 'test_initial_frame_copy.gsd', mode=open_mode.read
+    ) as hf:
         assert len(hf) == 2
 
         # Verify that the user does not get a reference to the initial frame cache.
@@ -1018,7 +1024,6 @@ def test_initial_frame_copy(tmp_path, open_mode):
         assert frame_1.angles.group is initial.angles.group
         assert not frame_1.angles.typeid.flags.writeable
         assert not frame_1.angles.group.flags.writeable
-
 
         assert frame_1.dihedrals.types is not initial.dihedrals.types
         assert frame_1.dihedrals.typeid is initial.dihedrals.typeid

--- a/gsd/test/test_hoomd.py
+++ b/gsd/test/test_hoomd.py
@@ -959,3 +959,91 @@ def test_read_log_warning(tmp_path):
         log = gsd.hoomd.read_log(tmp_path / 'test_log.gsd')
 
     assert list(log.keys()) == ['configuration/step']
+
+def test_initial_frame_copy(tmp_path, open_mode):
+    with gsd.hoomd.open(name=tmp_path / 'test_initial_frame_copy.gsd', mode=open_mode.write) as hf:
+        frame = make_nondefault_frame()
+
+        hf.append(frame)
+
+        frame.configuration.step *= 2
+        del frame.log['value']
+        hf.append(frame)
+
+    with gsd.hoomd.open(name=tmp_path / 'test_initial_frame_copy.gsd', mode=open_mode.read) as hf:
+        assert len(hf) == 2
+
+        # Verify that the user does not get a reference to the initial frame cache.
+        frame_0 = hf[0]
+        initial = hf._initial_frame
+        assert frame_0 is not initial
+
+        # Verify that no mutable objects from the initial frame cache are presented to
+        # the user.
+        frame_1 = hf[1]
+        assert frame_1.configuration.box is not initial.configuration.box
+        assert frame_1.particles.types is not initial.particles.types
+        assert frame_1.particles.type_shapes is not initial.particles.type_shapes
+        assert frame_1.particles.position is initial.particles.position
+        assert not frame_1.particles.position.flags.writeable
+        assert frame_1.particles.typeid is initial.particles.typeid
+        assert not frame_1.particles.typeid.flags.writeable
+        assert frame_1.particles.mass is initial.particles.mass
+        assert not frame_1.particles.mass.flags.writeable
+        assert frame_1.particles.diameter is initial.particles.diameter
+        assert not frame_1.particles.diameter.flags.writeable
+        assert frame_1.particles.body is initial.particles.body
+        assert not frame_1.particles.body.flags.writeable
+        assert frame_1.particles.charge is initial.particles.charge
+        assert not frame_1.particles.charge.flags.writeable
+        assert frame_1.particles.moment_inertia is initial.particles.moment_inertia
+        assert not frame_1.particles.moment_inertia.flags.writeable
+        assert frame_1.particles.orientation is initial.particles.orientation
+        assert not frame_1.particles.orientation.flags.writeable
+        assert frame_1.particles.velocity is initial.particles.velocity
+        assert not frame_1.particles.velocity.flags.writeable
+        assert frame_1.particles.angmom is initial.particles.angmom
+        assert not frame_1.particles.angmom.flags.writeable
+        assert frame_1.particles.image is initial.particles.image
+        assert not frame_1.particles.image.flags.writeable
+
+        assert frame_1.bonds.types is not initial.bonds.types
+        assert frame_1.bonds.typeid is initial.bonds.typeid
+        assert frame_1.bonds.group is initial.bonds.group
+        assert not frame_1.bonds.typeid.flags.writeable
+        assert not frame_1.bonds.group.flags.writeable
+
+        assert frame_1.angles.types is not initial.angles.types
+        assert frame_1.angles.typeid is initial.angles.typeid
+        assert frame_1.angles.group is initial.angles.group
+        assert not frame_1.angles.typeid.flags.writeable
+        assert not frame_1.angles.group.flags.writeable
+
+
+        assert frame_1.dihedrals.types is not initial.dihedrals.types
+        assert frame_1.dihedrals.typeid is initial.dihedrals.typeid
+        assert frame_1.dihedrals.group is initial.dihedrals.group
+        assert not frame_1.dihedrals.typeid.flags.writeable
+        assert not frame_1.dihedrals.group.flags.writeable
+
+        assert frame_1.impropers.types is not initial.impropers.types
+        assert frame_1.impropers.typeid is initial.impropers.typeid
+        assert frame_1.impropers.group is initial.impropers.group
+        assert not frame_1.impropers.typeid.flags.writeable
+        assert not frame_1.impropers.group.flags.writeable
+
+        assert frame_1.constraints.value is initial.constraints.value
+        assert frame_1.constraints.group is initial.constraints.group
+        assert not frame_1.constraints.value.flags.writeable
+        assert not frame_1.constraints.group.flags.writeable
+
+        assert frame_1.pairs.types is not initial.pairs.types
+        assert frame_1.pairs.typeid is initial.pairs.typeid
+        assert frame_1.pairs.group is initial.pairs.group
+        assert not frame_1.pairs.typeid.flags.writeable
+        assert not frame_1.pairs.group.flags.writeable
+
+        assert frame_1.log is not initial.log
+        for key in frame_1.log.keys():
+            assert frame_1.log[key] is initial.log[key]
+            assert not frame_1.log[key].flags.writeable

--- a/scripts/benchmark-hoomd.py
+++ b/scripts/benchmark-hoomd.py
@@ -20,13 +20,13 @@ import gsd.pygsd
 # logging.basicConfig(level=logging.DEBUG)
 
 
-def write_frame(file, frame, position, orientation):
+def write_frame(file, frame_idx, position, orientation):
     """Write a frame to the file."""
     frame = gsd.hoomd.Frame()
     frame.particles.N = position.shape[0]
-    frame.configuration.step = frame * 10
-    position[0][0] = frame
-    orientation[0][0] = frame
+    frame.configuration.step = frame_idx * 10
+    position[0][0] = frame_idx
+    orientation[0][0] = frame_idx
     frame.particles.position = position
     frame.particles.orientation = orientation
     file.append(frame)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Base backwards compatible bug fixes on `trunk-patch`. -->
<!-- Base additional functionality on `trunk-minor`. -->
<!-- Base API incompatible changes on `trunk-major`. -->

## Description

<!-- Describe your changes in detail. -->
1. Internally store a copy of the initial frame.
2. Return copies of mutable entries from the initial frame and default values.
3. Ensure that all non-copied numpy arrays from the initial frame are marked non-writable.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Many users expect to modify returned frames without error:
```
frame = trajectory[10]
frame.particles.types = ['A', 'B']
```

Prior to this pull request, such changes could modify the cached `_initial_frame` and/or default values.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
A new unit test verifies that the user is given copies of the 

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
- [x] I have added a change log entry to ``CHANGELOG.rst``.
