### PR TITLE
Cache existing chunks in frame 0.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,8 @@ Change Log
   (`#308 <https://github.com/glotzerlab/gsd/issues/308>`__).
 * Use ruff
   (`#317 <https://github.com/glotzerlab/gsd/pull/317>`__).
+* Perform fewer implicit flushes when using the ``gsd.hoomd`` python API
+  (`#325 <https://github.com/glotzerlab/gsd/pull/325>`__).
 
 3.2.0 (2023-09-27)
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Base backwards compatible bug fixes on `trunk-patch`. -->
<!-- Base additional functionality on `trunk-minor`. -->
<!-- Base API incompatible changes on `trunk-major`. -->

## Description

<!-- Describe your changes in detail. -->
Cache the results of `chunk_exists` calls from frame 0.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This increases performance. In cases where users write many values that match defaults, the previous code would check (for every single chunk) whether that chunk is present in frame 0:
```
DEBUG:gsd.hoomd:skipping data chunk, matches frame 0: particles/orientation
DEBUG:gsd.fl:chunk exists: test.gsd - particles/velocity
DEBUG:gsd.hoomd:writing data chunk: particles/velocity
DEBUG:gsd.fl:write chunk: test.gsd - particles/velocity
```
The `chunk_exists` call triggers an implicit flush which decreases write performance significantly.

After this change, the chunk_exists call is made once for frame 0 and the results are reused, resulting in no extra `chunk_exists` calls:
```
DEBUG:gsd.hoomd:skipping data chunk, matches frame 0: particles/orientation
DEBUG:gsd.hoomd:writing data chunk: particles/velocity
DEBUG:gsd.fl:write chunk: test.gsd - particles/velocity
```

## How Has This Been Tested?

Existing tests pass. 

`hoomd-benchmarks.py` does not trigger the extra `chunk_exists` calls, so it does not show any performance improvement. Use-cases that trigger it excessively should see improvement.

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
- [x] I have added a change log entry to ``CHANGELOG.rst``.
