### PR TITLE
Group depdendabot updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,34 +1,50 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    target-branch: trunk-patch
-    schedule:
-      interval: "weekly"
-      time: "07:00"
-      timezone: "EST5EDT"
-    pull-request-branch-name:
-      separator: "-"
-    open-pull-requests-limit: 2
-
-  - package-ecosystem: "pip"
-    directory: ".github"
-    target-branch: trunk-patch
-    schedule:
-      interval: "weekly"
-      time: "07:00"
-      timezone: "EST5EDT"
-    pull-request-branch-name:
-      separator: "-"
-    open-pull-requests-limit: 2
-
-  - package-ecosystem: "pip"
-    directory: "doc"
-    target-branch: trunk-patch
-    schedule:
-      interval: "weekly"
-      time: "07:00"
-      timezone: "EST5EDT"
-    pull-request-branch-name:
-      separator: "-"
-    open-pull-requests-limit: 2
+- package-ecosystem: "github-actions"
+  directory: "/"
+  target-branch: trunk-patch
+  schedule:
+    interval: "monthly"
+    time: "07:00"
+    timezone: "EST5EDT"
+  pull-request-branch-name:
+    separator: "-"
+  open-pull-requests-limit: 2
+  reviewers:
+  - joaander
+  groups:
+    version:
+      applies-to: version-updates
+      patterns:
+      - '*'
+    security:
+      applies-to: security-updates
+      patterns:
+      - '*'
+- package-ecosystem: "pip"
+  directory: "/"
+  target-branch: trunk-patch
+  schedule:
+    interval: "monthly"
+    time: "07:00"
+    timezone: "EST5EDT"
+  pull-request-branch-name:
+    separator: "-"
+  open-pull-requests-limit: 2
+  reviewers:
+  - joaander
+  groups:
+    version:
+      applies-to: version-updates
+      patterns:
+      - '*'
+      update-types:
+      - minor
+      - patch
+    security:
+      applies-to: security-updates
+      patterns:
+      - '*'
+      update-types:
+      - minor
+      - patch


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Base backwards compatible bug fixes on `trunk-patch`. -->
<!-- Base additional functionality on `trunk-minor`. -->
<!-- Base API incompatible changes on `trunk-major`. -->

## Description

<!-- Describe your changes in detail. -->
Group dependabot updates.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Reduce the number of dependabot pull requests.
The `group` option is new: https://github.blog/changelog/2023-08-24-grouped-version-updates-for-dependabot-are-generally-available/

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Dependabot will run with the new configuration after this is merged into the default branch.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
