### PR TITLE
Make numpy 2.0 requirement optional.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.4.1
+current_version = 3.4.2
 commit = False
 tag = False
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -64,7 +64,7 @@ body:
       label: GSD
       description: |
         What version of GSD are you using?
-      placeholder: 3.4.1
+      placeholder: 3.4.2
     validations:
       required: true
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,7 +1,7 @@
 ---
 name: Release checklist
 about: '[for maintainer use]'
-title: 'Release gsd 3.4.1'
+title: 'Release gsd 3.4.2'
 labels: ''
 assignees: 'joaander'
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,14 @@ Change Log
 3.x
 ---
 
+3.4.2 (2024-11-13)
+^^^^^^^^^^^^^^^^^^
+
+*Fixed:*
+
+* Make NumPy 2.0 requirement optional
+  (`#405 <https://github.com/glotzerlab/gsd/pull/405>`__).
+
 3.4.1 (2024-10-21)
 ^^^^^^^^^^^^^^^^^^
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -5,7 +5,7 @@
 #---------------------------------------------------------------------------
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "GSD"
-PROJECT_NUMBER         = v3.4.1
+PROJECT_NUMBER         = v3.4.2
 PROJECT_BRIEF          = "General simulation data"
 PROJECT_LOGO           =
 OUTPUT_DIRECTORY       = devdoc

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -1169,6 +1169,11 @@ def read_log(name, scalar_only=False):
         msg = 'gsd module is not available'
         raise RuntimeError(msg)
 
+    min_supported_numpy = 2
+    if int(numpy.version.version.split('.')[0]) < min_supported_numpy:
+        msg = 'read_log requires numpy >= 2.0'
+        raise RuntimeError(msg)
+
     with gsd.fl.open(
         name=str(name),
         mode='r',

--- a/gsd/pygsd.py
+++ b/gsd/pygsd.py
@@ -36,7 +36,7 @@ from collections import namedtuple
 
 import numpy
 
-version = '3.4.1'
+version = '3.4.2'
 
 logger = logging.getLogger('gsd.pygsd')
 

--- a/gsd/version.py
+++ b/gsd/version.py
@@ -9,7 +9,7 @@ Attributes:
                    not the file layer version it reads/writes.
 """
 
-version = '3.4.1'
+version = '3.4.2'
 
 __all__ = [
     'version',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 requires-python = ">=3.6"
 name = "gsd"
-version = "3.4.1"
+version = "3.4.2"
 description = "General simulation data file format."
 readme = "README.md"
 license = {text = "BSD-2-Clause"}
@@ -25,7 +25,7 @@ gsd = "gsd.__main__:main"
 [project.urls]
 Homepage = "https://gsd.readthedocs.io"
 Documentation = "https://gsd.readthedocs.io"
-Download = "https://github.com/glotzerlab/gsd/releases/download/v3.4.1/gsd-3.4.1.tar.gz"
+Download = "https://github.com/glotzerlab/gsd/releases/download/v3.4.2/gsd-3.4.2.tar.gz"
 Source = "https://github.com/glotzerlab/gsd"
 Issues = "https://github.com/glotzerlab/gsd/issues"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers=[
     "License :: OSI Approved :: BSD License",
     "Topic :: Scientific/Engineering :: Physics",
     ]
-dependencies = ["numpy>=2.0.0"]
+dependencies = ["numpy"]
 
 [project.scripts]
 gsd = "gsd.__main__:main"


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Base backwards compatible bug fixes on `trunk-patch`. -->
<!-- Base additional functionality on `trunk-minor`. -->
<!-- Base API incompatible changes on `trunk-major`. -->

## Description

<!-- Describe your changes in detail. -->
Raise a `RuntimeError` in `read_log` if numpy <2 is installed.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
satisfy pip check in conda-forge.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->
I downgraded to numpy 1.26 locally. All tests pass except `read_log` which issues the expected `RuntimeError`.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
- [x] I have added a change log entry to ``CHANGELOG.rst``.
