### PR TITLE
Document return type for `_read_frame`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Change Log
 
 *Fixed:*
 
-* Type hints for `HoomdTrajectory._read_frame` and downstream methods are now correct.
+* Type hints for ``HoomdTrajectory._read_frame`` and downstream methods are now correct.
 
 3.4.2 (2024-11-13)
 ^^^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,8 @@ Change Log
 
 3.x
 ---
-
+next (not yet released)
+^^^^^^^^^^^^^^^^^^^^^^^
 *Fixed:*
 
 * Type hints for ``HoomdTrajectory._read_frame`` and downstream methods are now correct.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Change Log
 3.x
 ---
 
+*Fixed:*
+
+* Type hints for `HoomdTrajectory._read_frame` and downstream methods are now correct.
+
 3.4.2 (2024-11-13)
 ^^^^^^^^^^^^^^^^^^
 

--- a/doc/credits.rst
+++ b/doc/credits.rst
@@ -19,3 +19,4 @@ The following people contributed to GSD.
 * Charlotte Shiqi Zhao, University of Michigan
 * Tim Moore, University of Michigan
 * Joseph Burkhart, University of Michigan
+* Jenna Bradley, University of Michigan

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -859,7 +859,7 @@ class HOOMDTrajectory:
             idx (int): Frame index to read.
 
         Returns:
-            `Frame` with the frame data
+            Frame : The frame data
 
         Replace any data chunks not present in the given frame with either data
         from frame 0, or initialize from default values if not in frame 0. Cache


### PR DESCRIPTION
## Description

The return type of the `_read_frame` function was added to the `Returns` docstring block to eliminate a warning raised by type hinters.

## Motivation and Context

Python type linters would make the incorrect assumption that `__getitem__` from a trajectory always returned a `HoomdTrajectoryView`, even through `__getitem__` with an int returns a gsd frame. This would lead to warnings like `Cannot access attribute "particles" for class "_HOOMDTrajectoryView"` when attempting to access properties that do not exist in a trajectory view. Updating the return type in the documentation of `_read_frame` fixes this issue.

## How Has This Been Tested?

The warning is no longer raised.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
- [x] I have added a change log entry to ``CHANGELOG.rst``.
