### PR TITLE
Improve write buffer performance

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,4 +16,5 @@ Checks: 'bugprone-*,
          -cert-dcl51-cpp,
          -bugprone-narrowing-conversions,
          -misc-include-cleaner,
+         -readability-magic-numbers,
          '

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ Change Log
   (`#417 <https://github.com/glotzerlab/gsd/pull/417>`__).
 * Sync changes to disk on macOS
   (`#429 <https://github.com/glotzerlab/gsd/pull/429>`__).
-* Sync index entries to disk before returning from `flush`
+* Sync index entries to disk before returning from ``flush``
   (`#429 <https://github.com/glotzerlab/gsd/pull/429>`__).
 * Work around macOS bug that mysteriously allocated 16 MB of extra disk blocks beyond the end
   of the file

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,18 +7,44 @@ Change Log
 `GSD <https://github.com/glotzerlab/gsd>`_ releases follow `semantic versioning
 <https://semver.org/>`_.
 
-3.x
+
+4.x
 ---
-next (not yet released)
-^^^^^^^^^^^^^^^^^^^^^^^
+
+4.0.0 (not yet released)
+^^^^^^^^^^^^^^^^^^^^^^^^
+
 *Fixed:*
 
-* Type hints for ``HoomdTrajectory._read_frame`` and downstream methods are now correct.
+* Type hints for ``HoomdTrajectory._read_frame`` and downstream methods are now correct
+  (`#417 <https://github.com/glotzerlab/gsd/pull/417>`__).
+* Sync changes to disk on macOS
+  (`#429 <https://github.com/glotzerlab/gsd/pull/429>`__).
+* Sync index entries to disk before returning from `flush`
+  (`#429 <https://github.com/glotzerlab/gsd/pull/429>`__).
+* Work around macOS bug that mysteriously allocated 16 MB of extra disk blocks beyond the end
+  of the file
+  (`#429 <https://github.com/glotzerlab/gsd/pull/429>`__).
 
 *Changed:*
 
 * No longer test with clang 10, 11, or 12
   (`#422 <https://github.com/glotzerlab/gsd/pull/422>`__).
+* [breaking] ``end_frame``, ``find_chunk``, ``find_matching_chunk_names``, and ``read_chunk`` no longer
+  implicitly call ``flush``. The caller must manually call ``flush`` (or close the file) before
+  chunks can be read. This behavior extends to the high level ``gsd.hoomd`` Python API
+  (`#429 <https://github.com/glotzerlab/gsd/pull/429>`__).
+* Set the default write buffer to 1 MB
+  (`#429 <https://github.com/glotzerlab/gsd/pull/429>`__).
+
+*Removed:*
+
+* ``index_entries_to_buffer``
+  (`#429 <https://github.com/glotzerlab/gsd/pull/429>`__).
+
+
+3.x
+---
 
 3.4.2 (2024-11-13)
 ^^^^^^^^^^^^^^^^^^

--- a/doc/fl-examples.rst
+++ b/doc/fl-examples.rst
@@ -171,6 +171,7 @@ Open a file in read/write mode
                     schema_version=[1,0])
     f.write_chunk(name='double', data=numpy.array([1,2,3,4], dtype=numpy.float64));
     f.end_frame()
+    f.flush()
     f.nframes
     f.read_chunk(frame=0, name='double')
 
@@ -200,6 +201,7 @@ Store string chunks
                     schema_version=[1,0])
     f.write_chunk(name='string', data="This is a string")
     f.end_frame()
+    f.flush()
     r = f.read_chunk(frame=0, name='string')
     r
     f.close()

--- a/gsd/fl.pyx
+++ b/gsd/fl.pyx
@@ -273,9 +273,6 @@ cdef class GSDFile:
         nframes (int): Number of frames.
 
         maximum_write_buffer_size (int): The Maximum write buffer size (bytes).
-
-        index_entries_to_buffer (int): Number of index entries to buffer before
-            flushing.
     """
 
     cdef libgsd.gsd_handle __handle
@@ -1005,20 +1002,6 @@ cdef class GSDFile:
                 raise ValueError("File is not open")
 
             retval = libgsd.gsd_set_maximum_write_buffer_size(&self.__handle, size)
-            __raise_on_error(retval, self.name)
-
-    property index_entries_to_buffer:
-        def __get__(self):
-            if not self.__is_open:
-                raise ValueError("File is not open")
-
-            return libgsd.gsd_get_index_entries_to_buffer(&self.__handle)
-
-        def __set__(self, number):
-            if not self.__is_open:
-                raise ValueError("File is not open")
-
-            retval = libgsd.gsd_set_index_entries_to_buffer(&self.__handle, number)
             __raise_on_error(retval, self.name)
 
     def __dealloc__(self):

--- a/gsd/fl.pyx
+++ b/gsd/fl.pyx
@@ -454,6 +454,10 @@ cdef class GSDFile:
         future calls to :py:meth:`write_chunk()` will write to the **next**
         frame in the file.
 
+        :py:meth:`end_frame()` does NOT write frames to the underlying file.
+        Complete frames will be available to read from the file 1) after the
+        file is closed or 2) after a call to :py:meth:`flush()` completes.
+
         .. danger::
             Call :py:meth:`end_frame()` to complete the current frame
             **before** closing the file. If you fail to call
@@ -478,6 +482,7 @@ cdef class GSDFile:
                               data=numpy.array([13,14],
                                                dtype=numpy.float32))
                 f.end_frame()
+                f.flush()
                 f.nframes
                 f.close()
 
@@ -547,6 +552,7 @@ cdef class GSDFile:
                               data=numpy.array([70,80,90],
                                                dtype=numpy.int64))
                 f.end_frame()
+                f.flush()
                 f.nframes
                 f.close()
         """

--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -99,7 +99,7 @@ int S_IWUSR = _S_IWRITE;
 int S_IRGRP = _S_IREAD;
 int S_IWGRP = _S_IWRITE;
 
-inline int gsd_fsync(int fd)
+int gsd_fsync(int fd)
     {
     return _commit(fd);
     }
@@ -131,12 +131,12 @@ inline ssize_t pwrite(int fd, const void* buf, size_t count, int64_t offset)
     }
 
 #elif defined(__APPLE__)
-inline int gsd_fsync(int fd)
+int gsd_fsync(int fd)
     {
     return fcntl(fd, F_FULLFSYNC);
     }
 #else
-inline int gsd_fsync(int fd)
+int gsd_fsync(int fd)
     {
     return fsync(fd);
     }
@@ -1989,7 +1989,7 @@ int gsd_flush(struct gsd_handle* handle)
 #if !GSD_USE_MMAP
         // add the entries to the file index
         memcpy(handle->file_index.data + handle->file_index.size,
-               handle->frame_index.data,
+               handle->buffer_index.data,
                sizeof(struct gsd_index_entry) * index_entries_to_write);
 #endif
 
@@ -2395,7 +2395,7 @@ int gsd_upgrade(struct gsd_handle* handle)
         {
         return GSD_ERROR_INVALID_ARGUMENT;
         }
-    if (handle->frame_index.size > 0 || handle->frame_names.n_names > 0)
+    if (handle->buffer_index.size > 0 || handle->frame_names.n_names > 0)
         {
         return GSD_ERROR_INVALID_ARGUMENT;
         }

--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -633,15 +633,13 @@ inline static int gsd_index_buffer_map(struct gsd_index_buffer* buf, struct gsd_
 
 #if GSD_USE_MMAP
     // map the index in read only mode
-    size_t page_size = getpagesize();
     size_t index_size = sizeof(struct gsd_index_entry) * handle->header.index_allocated_entries;
-    size_t offset = (handle->header.index_location / page_size) * page_size;
     buf->mapped_data = mmap(NULL,
-                            index_size + (handle->header.index_location - offset),
+                            index_size + handle->header.index_location,
                             PROT_READ,
                             MAP_SHARED,
                             handle->fd,
-                            offset);
+                            0);
 
     if (buf->mapped_data == MAP_FAILED)
         {
@@ -649,9 +647,9 @@ inline static int gsd_index_buffer_map(struct gsd_index_buffer* buf, struct gsd_
         }
 
     buf->data = (struct gsd_index_entry*)(((char*)buf->mapped_data)
-                                          + (handle->header.index_location - offset));
+                                          + handle->header.index_location);
 
-    buf->mapped_len = index_size + (handle->header.index_location - offset);
+    buf->mapped_len = index_size + handle->header.index_location;
     buf->reserved = handle->header.index_allocated_entries;
 #else
     // mmap not supported, read the data from the disk

--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -98,13 +98,17 @@ enum
 #ifdef _WIN32
 #define lseek _lseeki64
 #define ftruncate _chsize
-#define gsd_fsync _commit
 typedef int64_t ssize_t;
 
 int S_IRUSR = _S_IREAD;
 int S_IWUSR = _S_IWRITE;
 int S_IRGRP = _S_IREAD;
 int S_IWGRP = _S_IWRITE;
+
+inline int gsd_fsync(int fd)
+    {
+    return _commit(fd);
+    }
 
 inline ssize_t pread(int fd, void* buf, size_t count, int64_t offset)
     {
@@ -137,8 +141,11 @@ inline int gsd_fsync(int fd)
     {
     return fcntl(fd, F_FULLFSYNC);
     }
-#elif
-#define gsd_fsync fsync
+#else
+inline int gsd_fsync(int fd)
+    {
+    return fsync(fd);
+    }
 #endif
 
 /** Zero memory
@@ -1163,13 +1170,6 @@ inline static int gsd_flush_write_buffer(struct gsd_handle* handle)
     // clear the buffer index for new entries
     handle->buffer_index.size = 0;
 
-    // sync the data before writing the index
-    int retval = gsd_fsync(handle->fd);
-    if (retval != 0)
-        {
-        return GSD_ERROR_IO;
-        }
-
     return GSD_SUCCESS;
     }
 
@@ -1995,6 +1995,13 @@ int gsd_flush(struct gsd_handle* handle)
     if (retval != GSD_SUCCESS)
         {
         return retval;
+        }
+
+    // sync the data before writing the index
+    retval = gsd_fsync(handle->fd);
+    if (retval != 0)
+        {
+        return GSD_ERROR_IO;
         }
 
     // Write the frame index to the file, excluding the index entries that are part of the current

--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -985,7 +985,18 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
         return retval;
         }
 
-    // allocate the copy buffer
+    int64_t new_index_location = lseek(handle->fd, 0, SEEK_END);
+    int64_t old_index_location = handle->header.index_location;
+
+    // fill the new index space with 0s
+    size_t new_index_bytes = size_new * sizeof(struct gsd_index_entry);
+    retval = ftruncate(handle->fd, new_index_location + new_index_bytes);
+    if (retval != 0)
+        {
+        return GSD_ERROR_IO;
+        }
+
+    // write the current index to the end of the file
     uint64_t copy_buffer_size
         = GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_SIZE;
     if (copy_buffer_size > size_old * sizeof(struct gsd_index_entry))
@@ -993,10 +1004,7 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
         copy_buffer_size = size_old * sizeof(struct gsd_index_entry);
         }
     char* buf = malloc(copy_buffer_size);
-
-    // write the current index to the end of the file
-    int64_t new_index_location = lseek(handle->fd, 0, SEEK_END);
-    int64_t old_index_location = handle->header.index_location;
+    
     size_t total_bytes_written = 0;
     size_t old_index_bytes = size_old * sizeof(struct gsd_index_entry);
     while (total_bytes_written < old_index_bytes)
@@ -1030,15 +1038,6 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
             }
 
         total_bytes_written += bytes_written;
-        }
-
-    // fill the new index space with 0s
-    size_t new_index_bytes = size_new * sizeof(struct gsd_index_entry);
-    retval = ftruncate(handle->fd, new_index_location + new_index_bytes);
-    if (retval != 0)
-        {
-        free(buf);
-        return GSD_ERROR_IO;
         }
 
     // sync the expanded index

--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -65,10 +65,10 @@ enum
     GSD_INITIAL_WRITE_BUFFER_SIZE = 1024
     };
 
-/// Default maximum size of write buffer
+/// Default maximum size of write buffer (in bytes)
 enum
     {
-    GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_SIZE = 1024 * 1024
+    GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_BYTES = 1024 * 1024
     };
 
 /// Size of hash map
@@ -995,7 +995,7 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
         }
 
     // write the current index to the end of the file
-    uint64_t copy_buffer_size = GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_SIZE;
+    uint64_t copy_buffer_size = GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_BYTES;
     if (copy_buffer_size > size_old * sizeof(struct gsd_index_entry))
         {
         copy_buffer_size = size_old * sizeof(struct gsd_index_entry);
@@ -1568,7 +1568,7 @@ inline static int gsd_initialize_handle(struct gsd_handle* handle)
         }
 
     handle->pending_index_entries = 0;
-    handle->maximum_write_buffer_size = GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_SIZE;
+    handle->maximum_write_buffer_size = GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_BYTES;
 
     // Silently upgrade writable files from a previous matching major version to the latest
     // minor version.

--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -185,6 +185,7 @@ inline static ssize_t gsd_io_pwrite_retry(int fd, const void* buf, size_t count,
         errno = 0;
         ssize_t bytes_written
             = pwrite(fd, ptr + total_bytes_written, to_write, offset + total_bytes_written);
+
         if (bytes_written == -1 || (bytes_written == 0 && errno != 0))
             {
             return GSD_ERROR_IO;
@@ -1032,29 +1033,12 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
         }
 
     // fill the new index space with 0s
-    gsd_util_zero_memory(buf, copy_buffer_size);
-
     size_t new_index_bytes = size_new * sizeof(struct gsd_index_entry);
-    while (total_bytes_written < new_index_bytes)
+    retval = ftruncate(handle->fd, new_index_location + new_index_bytes);
+    if (retval != 0)
         {
-        size_t bytes_to_copy = copy_buffer_size;
-        if (new_index_bytes - total_bytes_written < copy_buffer_size)
-            {
-            bytes_to_copy = new_index_bytes - total_bytes_written;
-            }
-
-        ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd,
-                                                    buf,
-                                                    bytes_to_copy,
-                                                    new_index_location + total_bytes_written);
-
-        if (bytes_written == -1 || bytes_written != bytes_to_copy)
-            {
-            free(buf);
-            return GSD_ERROR_IO;
-            }
-
-        total_bytes_written += bytes_written;
+        free(buf);
+        return GSD_ERROR_IO;
         }
 
     // sync the expanded index
@@ -1070,7 +1054,7 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
 
     // update the header
     handle->header.index_location = new_index_location;
-    handle->file_size = handle->header.index_location + total_bytes_written;
+    handle->file_size = new_index_location + new_index_bytes;
     handle->header.index_allocated_entries = size_new;
 
     // write the new header out

--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -68,7 +68,7 @@ enum
 /// Default maximum size of write buffer
 enum
     {
-    GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_SIZE = 64 * 1024 * 1024
+    GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_SIZE = 1024 * 1024
     };
 
 /// Size of hash map

--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -1102,10 +1102,9 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
     @brief Flush the write buffer.
 
     gsd_write_frame() writes small data chunks into the write buffer. It adds index entries for
-    these chunks to gsd_handle::buffer_index with locations offset from the start of the write
-    buffer. gsd_flush_write_buffer() writes the buffer to the end of the file, moves the index
-    entries to gsd_handle::frame_index and updates the location to reference the beginning of the
-    file.
+    these chunks to gsd_handle::buffer_index with locations offset from the current end of file.
+    gsd_flush_write_buffer() writes the buffer to the end of the file. The entries in the buffered
+    index have valid locations because nothing else writes past the end of the file.
 
     @param handle Handle to flush the write buffer.
     @returns GSD_SUCCESS on success or GSD_* error codes on error
@@ -1117,16 +1116,10 @@ inline static int gsd_flush_write_buffer(struct gsd_handle* handle)
         return GSD_ERROR_INVALID_ARGUMENT;
         }
 
-    if (handle->write_buffer.size == 0 && handle->buffer_index.size == 0)
+    if (handle->write_buffer.size == 0)
         {
         // nothing to do
         return GSD_SUCCESS;
-        }
-
-    if (handle->write_buffer.size > 0 && handle->buffer_index.size == 0)
-        {
-        // error: bytes in buffer, but no index for them
-        return GSD_ERROR_INVALID_ARGUMENT;
         }
 
     // write the buffer to the end of the file
@@ -1145,24 +1138,6 @@ inline static int gsd_flush_write_buffer(struct gsd_handle* handle)
 
     // reset write_buffer for new data
     handle->write_buffer.size = 0;
-
-    // Move buffer_index entries to frame_index.
-    size_t i;
-    for (i = 0; i < handle->buffer_index.size; i++)
-        {
-        struct gsd_index_entry* new_index;
-        int retval = gsd_index_buffer_add(&handle->frame_index, &new_index);
-        if (retval != GSD_SUCCESS)
-            {
-            return retval;
-            }
-
-        *new_index = handle->buffer_index.data[i];
-        new_index->location += offset;
-        }
-
-    // clear the buffer index for new entries
-    handle->buffer_index.size = 0;
 
     return GSD_SUCCESS;
     }
@@ -1592,12 +1567,6 @@ inline static int gsd_initialize_handle(struct gsd_handle* handle)
     // if this is a write mode, allocate the initial frame index and the name buffer
     if (handle->open_flags != GSD_OPEN_READONLY)
         {
-        retval = gsd_index_buffer_allocate(&handle->frame_index, GSD_INITIAL_FRAME_INDEX_SIZE);
-        if (retval != GSD_SUCCESS)
-            {
-            return retval;
-            }
-
         retval = gsd_index_buffer_allocate(&handle->buffer_index, GSD_INITIAL_FRAME_INDEX_SIZE);
         if (retval != GSD_SUCCESS)
             {
@@ -1812,15 +1781,6 @@ int gsd_truncate(struct gsd_handle* handle)
         return retval;
         }
 
-    if (handle->frame_index.reserved > 0)
-        {
-        retval = gsd_index_buffer_free(&handle->frame_index);
-        if (retval != GSD_SUCCESS)
-            {
-            return retval;
-            }
-        }
-
     if (handle->buffer_index.reserved > 0)
         {
         retval = gsd_index_buffer_free(&handle->buffer_index);
@@ -1879,15 +1839,6 @@ int gsd_close(struct gsd_handle* handle)
     if (retval != GSD_SUCCESS)
         {
         return retval;
-        }
-
-    if (handle->frame_index.reserved > 0)
-        {
-        retval = gsd_index_buffer_free(&handle->frame_index);
-        if (retval != GSD_SUCCESS)
-            {
-            return retval;
-            }
         }
 
     if (handle->buffer_index.reserved > 0)
@@ -1972,15 +1923,15 @@ int gsd_flush(struct gsd_handle* handle)
         return GSD_ERROR_FILE_MUST_BE_WRITABLE;
         }
 
-    // flush the namelist buffer
-    int retval = gsd_flush_name_buffer(handle);
+    // flush the write buffer first so that all locations in the buffer_index are maintained.
+    int retval = gsd_flush_write_buffer(handle);
     if (retval != GSD_SUCCESS)
         {
         return retval;
         }
 
-    // flush the write buffer
-    retval = gsd_flush_write_buffer(handle);
+    // flush the namelist buffer
+    retval = gsd_flush_name_buffer(handle);
     if (retval != GSD_SUCCESS)
         {
         return retval;
@@ -1993,13 +1944,13 @@ int gsd_flush(struct gsd_handle* handle)
         return GSD_ERROR_IO;
         }
 
-    // Write the frame index to the file, excluding the index entries that are part of the current
+    // Write the buffer index to the file, excluding the index entries that are part of the current
     // frame.
-    if (handle->pending_index_entries > handle->frame_index.size)
+    if (handle->pending_index_entries > handle->buffer_index.size)
         {
         return GSD_ERROR_INVALID_ARGUMENT;
         }
-    uint64_t index_entries_to_write = handle->frame_index.size - handle->pending_index_entries;
+    uint64_t index_entries_to_write = handle->buffer_index.size - handle->pending_index_entries;
 
     if (index_entries_to_write > 0)
         {
@@ -2010,7 +1961,7 @@ int gsd_flush(struct gsd_handle* handle)
             }
 
         // sort the index before writing
-        retval = gsd_index_buffer_sort(&handle->frame_index);
+        retval = gsd_index_buffer_sort(&handle->buffer_index);
         if (retval != 0)
             {
             return retval;
@@ -2022,12 +1973,13 @@ int gsd_flush(struct gsd_handle* handle)
 
         size_t bytes_to_write = sizeof(struct gsd_index_entry) * index_entries_to_write;
         ssize_t bytes_written
-            = gsd_io_pwrite_retry(handle->fd, handle->frame_index.data, bytes_to_write, write_pos);
+            = gsd_io_pwrite_retry(handle->fd, handle->buffer_index.data, bytes_to_write, write_pos);
 
         if (bytes_written == -1 || bytes_written != bytes_to_write)
             {
             return GSD_ERROR_IO;
             }
+
         retval = gsd_fsync(handle->fd);
         if (retval != 0)
             {
@@ -2049,13 +2001,13 @@ int gsd_flush(struct gsd_handle* handle)
             {
             for (uint64_t i = 0; i < handle->pending_index_entries; i++)
                 {
-                handle->frame_index.data[i]
-                    = handle->frame_index
-                          .data[handle->frame_index.size - handle->pending_index_entries + i];
+                handle->buffer_index.data[i]
+                    = handle->buffer_index
+                          .data[handle->buffer_index.size - handle->pending_index_entries + i];
                 }
             }
 
-        handle->frame_index.size = handle->pending_index_entries;
+        handle->buffer_index.size = handle->pending_index_entries;
         }
 
     handle->file_frame = handle->buffer_frame;
@@ -2114,29 +2066,31 @@ int gsd_write_chunk(struct gsd_handle* handle,
     entry.type = (uint8_t)type;
     entry.N = N;
     entry.M = M;
+    entry.location = handle->file_size + handle->write_buffer.size;
     size_t size = N * M * gsd_sizeof_type(type);
 
-    // decide whether to write this chunk to the buffer or straight to disk
-    if (size < handle->maximum_write_buffer_size)
+    // flush the buffer if this entry won't fit
+    if (size > (handle->maximum_write_buffer_size - handle->write_buffer.size))
         {
-        // flush the buffer if this entry won't fit
-        if (size > (handle->maximum_write_buffer_size - handle->write_buffer.size))
-            {
-            gsd_flush_write_buffer(handle);
-            }
-
-        entry.location = handle->write_buffer.size;
-
-        // add an entry to the buffer index
-        struct gsd_index_entry* index_entry;
-
-        int retval = gsd_index_buffer_add(&handle->buffer_index, &index_entry);
+        int retval = gsd_flush_write_buffer(handle);
         if (retval != GSD_SUCCESS)
             {
             return retval;
             }
-        *index_entry = entry;
+        }
 
+    // add an entry to the buffer index
+    struct gsd_index_entry* index_entry;
+    int retval = gsd_index_buffer_add(&handle->buffer_index, &index_entry);
+    if (retval != GSD_SUCCESS)
+        {
+        return retval;
+        }
+    *index_entry = entry;
+
+    // decide whether to write this chunk to the buffer or straight to disk
+    if (size < handle->maximum_write_buffer_size)
+        {
         // add the data to the write buffer
         if (size > 0)
             {
@@ -2149,21 +2103,8 @@ int gsd_write_chunk(struct gsd_handle* handle,
         }
     else
         {
-        // add an entry to the frame index
-        struct gsd_index_entry* index_entry;
-
-        int retval = gsd_index_buffer_add(&handle->frame_index, &index_entry);
-        if (retval != GSD_SUCCESS)
-            {
-            return retval;
-            }
-        *index_entry = entry;
-
-        // find the location at the end of the file for the chunk
-        index_entry->location = handle->file_size;
-
         // write the data
-        ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd, data, size, index_entry->location);
+        ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd, data, size, entry.location);
         if (bytes_written == -1 || bytes_written != size)
             {
             return GSD_ERROR_IO;

--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -1581,12 +1581,13 @@ inline static int gsd_initialize_handle(struct gsd_handle* handle)
     // determine the current frame counter
     if (handle->file_index.size == 0)
         {
-        handle->cur_frame = 0;
+        handle->file_frame = 0;
         }
     else
         {
-        handle->cur_frame = handle->file_index.data[handle->file_index.size - 1].frame + 1;
+        handle->file_frame = handle->file_index.data[handle->file_index.size - 1].frame + 1;
         }
+    handle->buffer_frame = handle->file_frame;
 
     // if this is a write mode, allocate the initial frame index and the name buffer
     if (handle->open_flags != GSD_OPEN_READONLY)
@@ -1954,13 +1955,8 @@ int gsd_end_frame(struct gsd_handle* handle)
         return GSD_ERROR_FILE_MUST_BE_WRITABLE;
         }
 
-    handle->cur_frame++;
+    handle->buffer_frame++;
     handle->pending_index_entries = 0;
-
-    if (handle->frame_index.size > 0)
-        {
-        return gsd_flush(handle);
-        }
 
     return GSD_SUCCESS;
     }
@@ -2062,6 +2058,8 @@ int gsd_flush(struct gsd_handle* handle)
         handle->frame_index.size = handle->pending_index_entries;
         }
 
+    handle->file_frame = handle->buffer_frame;
+
     return GSD_SUCCESS;
     }
 
@@ -2111,7 +2109,7 @@ int gsd_write_chunk(struct gsd_handle* handle,
     struct gsd_index_entry entry;
     // populate fields in the entry's data
     gsd_util_zero_memory(&entry, sizeof(struct gsd_index_entry));
-    entry.frame = handle->cur_frame;
+    entry.frame = handle->buffer_frame;
     entry.id = id;
     entry.type = (uint8_t)type;
     entry.N = N;
@@ -2185,7 +2183,7 @@ uint64_t gsd_get_nframes(struct gsd_handle* handle)
         {
         return 0;
         }
-    return handle->cur_frame;
+    return handle->file_frame;
     }
 
 const struct gsd_index_entry*
@@ -2202,14 +2200,6 @@ gsd_find_chunk(struct gsd_handle* handle, uint64_t frame, const char* name)
     if (frame >= gsd_get_nframes(handle))
         {
         return NULL;
-        }
-    if (handle->open_flags != GSD_OPEN_READONLY)
-        {
-        int retval = gsd_flush(handle);
-        if (retval != GSD_SUCCESS)
-            {
-            return NULL;
-            }
         }
 
     // find the id for the given name
@@ -2300,14 +2290,6 @@ int gsd_read_chunk(struct gsd_handle* handle, void* data, const struct gsd_index
     if (chunk == NULL)
         {
         return GSD_ERROR_INVALID_ARGUMENT;
-        }
-    if (handle->open_flags != GSD_OPEN_READONLY)
-        {
-        int retval = gsd_flush(handle);
-        if (retval != GSD_SUCCESS)
-            {
-            return retval;
-            }
         }
 
     size_t size = chunk->N * chunk->M * gsd_sizeof_type((enum gsd_type)chunk->type);
@@ -2403,14 +2385,6 @@ gsd_find_matching_chunk_name(struct gsd_handle* handle, const char* match, const
     if (handle->file_names.n_names == 0)
         {
         return NULL;
-        }
-    if (handle->open_flags != GSD_OPEN_READONLY)
-        {
-        int retval = gsd_flush(handle);
-        if (retval != GSD_SUCCESS)
-            {
-            return NULL;
-            }
         }
 
     // return nothing found if the name buffer is corrupt

--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -98,7 +98,7 @@ enum
 #ifdef _WIN32
 #define lseek _lseeki64
 #define ftruncate _chsize
-#define fsync _commit
+#define gsd_fsync _commit
 typedef int64_t ssize_t;
 
 int S_IRUSR = _S_IREAD;
@@ -132,6 +132,13 @@ inline ssize_t pwrite(int fd, const void* buf, size_t count, int64_t offset)
     return result;
     }
 
+#elif defined(__APPLE__)
+inline int gsd_fsync(int fd)
+    {
+    return fcntl(fd, F_FULLFSYNC);
+    }
+#elif
+#define gsd_fsync fsync
 #endif
 
 /** Zero memory
@@ -1050,7 +1057,7 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
         }
 
     // sync the expanded index
-    retval = fsync(handle->fd);
+    retval = gsd_fsync(handle->fd);
     if (retval != 0)
         {
         free(buf);
@@ -1074,7 +1081,7 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
         }
 
     // sync the updated header
-    retval = fsync(handle->fd);
+    retval = gsd_fsync(handle->fd);
     if (retval != 0)
         {
         return GSD_ERROR_IO;
@@ -1226,7 +1233,7 @@ inline static int gsd_flush_name_buffer(struct gsd_handle* handle)
             }
 
         // sync the updated name list
-        retval = fsync(handle->fd);
+        retval = gsd_fsync(handle->fd);
         if (retval != 0)
             {
             return GSD_ERROR_IO;
@@ -1260,7 +1267,7 @@ inline static int gsd_flush_name_buffer(struct gsd_handle* handle)
         }
 
     // sync the updated name list or header
-    retval = fsync(handle->fd);
+    retval = gsd_fsync(handle->fd);
     if (retval != 0)
         {
         return GSD_ERROR_IO;
@@ -1433,7 +1440,7 @@ gsd_initialize_file(int fd, const char* application, const char* schema, uint32_
         }
 
     // sync file
-    retval = fsync(fd);
+    retval = gsd_fsync(fd);
     if (retval != 0)
         {
         return GSD_ERROR_IO;
@@ -1984,7 +1991,7 @@ int gsd_flush(struct gsd_handle* handle)
         }
 
     // sync the data before writing the index
-    retval = fsync(handle->fd);
+    retval = gsd_fsync(handle->fd);
     if (retval != 0)
         {
         return GSD_ERROR_IO;
@@ -2516,7 +2523,7 @@ int gsd_upgrade(struct gsd_handle* handle)
                 }
 
             // sync the updated index
-            retval = fsync(handle->fd);
+            retval = gsd_fsync(handle->fd);
             if (retval != 0)
                 {
                 return GSD_ERROR_IO;
@@ -2574,7 +2581,7 @@ int gsd_upgrade(struct gsd_handle* handle)
             handle->file_names.data = new_name_buf;
 
             // sync the updated name list
-            retval = fsync(handle->fd);
+            retval = gsd_fsync(handle->fd);
             if (retval != 0)
                 {
                 gsd_byte_buffer_free(&new_name_buf);
@@ -2595,7 +2602,7 @@ int gsd_upgrade(struct gsd_handle* handle)
             }
 
         // sync the updated header
-        int retval = fsync(handle->fd);
+        int retval = gsd_fsync(handle->fd);
         if (retval != 0)
             {
             return GSD_ERROR_IO;

--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -71,12 +71,6 @@ enum
     GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_SIZE = 64 * 1024 * 1024
     };
 
-/// Default number of index entries to buffer
-enum
-    {
-    GSD_DEFAULT_INDEX_ENTRIES_TO_BUFFER = 256 * 1024
-    };
-
 /// Size of hash map
 enum
     {
@@ -992,7 +986,7 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
 
     // allocate the copy buffer
     uint64_t copy_buffer_size
-        = GSD_DEFAULT_INDEX_ENTRIES_TO_BUFFER * sizeof(struct gsd_index_entry);
+        = GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_SIZE;
     if (copy_buffer_size > size_old * sizeof(struct gsd_index_entry))
         {
         copy_buffer_size = size_old * sizeof(struct gsd_index_entry);
@@ -1625,7 +1619,6 @@ inline static int gsd_initialize_handle(struct gsd_handle* handle)
 
     handle->pending_index_entries = 0;
     handle->maximum_write_buffer_size = GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_SIZE;
-    handle->index_entries_to_buffer = GSD_DEFAULT_INDEX_ENTRIES_TO_BUFFER;
 
     // Silently upgrade writable files from a previous matching major version to the latest
     // minor version.
@@ -1964,7 +1957,7 @@ int gsd_end_frame(struct gsd_handle* handle)
     handle->cur_frame++;
     handle->pending_index_entries = 0;
 
-    if (handle->frame_index.size > 0 || handle->buffer_index.size > handle->index_entries_to_buffer)
+    if (handle->frame_index.size > 0)
         {
         return gsd_flush(handle);
         }
@@ -2654,27 +2647,6 @@ int gsd_set_maximum_write_buffer_size(struct gsd_handle* handle, uint64_t size)
         }
 
     handle->maximum_write_buffer_size = size;
-
-    return GSD_SUCCESS;
-    }
-
-uint64_t gsd_get_index_entries_to_buffer(struct gsd_handle* handle)
-    {
-    if (handle == NULL)
-        {
-        return 0;
-        }
-    return handle->index_entries_to_buffer;
-    }
-
-int gsd_set_index_entries_to_buffer(struct gsd_handle* handle, uint64_t number)
-    {
-    if (handle == NULL || number == 0)
-        {
-        return GSD_ERROR_INVALID_ARGUMENT;
-        }
-
-    handle->index_entries_to_buffer = number;
 
     return GSD_SUCCESS;
     }

--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -646,8 +646,8 @@ inline static int gsd_index_buffer_map(struct gsd_index_buffer* buf, struct gsd_
         return GSD_ERROR_IO;
         }
 
-    buf->data = (struct gsd_index_entry*)(((char*)buf->mapped_data)
-                                          + handle->header.index_location);
+    buf->data
+        = (struct gsd_index_entry*)(((char*)buf->mapped_data) + handle->header.index_location);
 
     buf->mapped_len = index_size + handle->header.index_location;
     buf->reserved = handle->header.index_allocated_entries;
@@ -995,14 +995,13 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
         }
 
     // write the current index to the end of the file
-    uint64_t copy_buffer_size
-        = GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_SIZE;
+    uint64_t copy_buffer_size = GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_SIZE;
     if (copy_buffer_size > size_old * sizeof(struct gsd_index_entry))
         {
         copy_buffer_size = size_old * sizeof(struct gsd_index_entry);
         }
     char* buf = malloc(copy_buffer_size);
-    
+
     size_t total_bytes_written = 0;
     size_t old_index_bytes = size_old * sizeof(struct gsd_index_entry);
     while (total_bytes_written < old_index_bytes)

--- a/gsd/gsd.c
+++ b/gsd/gsd.c
@@ -1163,6 +1163,13 @@ inline static int gsd_flush_write_buffer(struct gsd_handle* handle)
     // clear the buffer index for new entries
     handle->buffer_index.size = 0;
 
+    // sync the data before writing the index
+    int retval = gsd_fsync(handle->fd);
+    if (retval != 0)
+        {
+        return GSD_ERROR_IO;
+        }
+
     return GSD_SUCCESS;
     }
 
@@ -1990,13 +1997,6 @@ int gsd_flush(struct gsd_handle* handle)
         return retval;
         }
 
-    // sync the data before writing the index
-    retval = gsd_fsync(handle->fd);
-    if (retval != 0)
-        {
-        return GSD_ERROR_IO;
-        }
-
     // Write the frame index to the file, excluding the index entries that are part of the current
     // frame.
     if (handle->pending_index_entries > handle->frame_index.size)
@@ -2029,6 +2029,11 @@ int gsd_flush(struct gsd_handle* handle)
             = gsd_io_pwrite_retry(handle->fd, handle->frame_index.data, bytes_to_write, write_pos);
 
         if (bytes_written == -1 || bytes_written != bytes_to_write)
+            {
+            return GSD_ERROR_IO;
+            }
+        retval = gsd_fsync(handle->fd);
+        if (retval != 0)
             {
             return GSD_ERROR_IO;
             }

--- a/gsd/gsd.h
+++ b/gsd/gsd.h
@@ -438,9 +438,11 @@ extern "C"
         @pre *handle* was opened by gsd_open().
 
         @post Writable files: All data and index entries buffered before the previous call to
-              gsd_end_frame() is written to the file (see gsd_flush()).
+              gsd_end_frame() is written to the file by implicitly calling gsd_flush().
         @post The file is closed.
         @post *handle* is freed and can no longer be used.
+
+        @note There is no need to manually call gsd_flush() before gsd_close().
 
         @warning Ensure that all gsd_write_chunk() calls are completed with gsd_end_frame() before
         closing the file.

--- a/gsd/gsd.h
+++ b/gsd/gsd.h
@@ -306,8 +306,11 @@ extern "C"
         /// List of names added in the current frame
         struct gsd_name_buffer frame_names;
 
-        /// The index of the last frame in the file
-        uint64_t cur_frame;
+        /// The index of the last frame in the buffer
+        uint64_t buffer_frame;
+
+        /// The index of the last frame comitted to the file
+        uint64_t file_frame;
 
         /// Size of the file (in bytes)
         int64_t file_size;
@@ -459,7 +462,10 @@ extern "C"
         @pre *handle* was opened by gsd_open().
 
         @post The current frame counter is increased by 1.
-        @post Flush the write buffer if it has overflowed. See gsd_flush().
+
+        @note Starting with GSD 4.0, gsd_end_frame() does NOT automatically flush buffered frames
+        to the filesystem. Callers must manually call gsd_flush() or gsd_close() to commit the
+        buffered frames to the filesystem.
 
         @return
           - GSD_SUCCESS (0) on success. Negative value on failure:
@@ -542,7 +548,8 @@ extern "C"
 
         @return A pointer to the found chunk, or NULL if not found.
 
-        @note gsd_find_chunk() calls gsd_flush() when the file is writable.
+        @note In read/write files gsd_find_chunk() can only find chunks that have been committed
+        to the file with gsd_flush().
     */
     const struct gsd_index_entry*
     gsd_find_chunk(struct gsd_handle* handle, uint64_t frame, const char* name);
@@ -565,7 +572,8 @@ extern "C"
           - GSD_ERROR_FILE_MUST_BE_READABLE: The file was opened in append mode.
           - GSD_ERROR_FILE_CORRUPT: The GSD file is corrupt.
 
-        @note gsd_read_chunk() calls gsd_flush() when the file is writable.
+        @note In read/write files gsd_read_chunk() can only read chunks that have been committed
+        to the file with gsd_flush().
     */
     int gsd_read_chunk(struct gsd_handle* handle, void* data, const struct gsd_index_entry* chunk);
 
@@ -603,7 +611,8 @@ extern "C"
         @return Pointer to a string, NULL if no more matching chunks are found found, or NULL if
         *prev* is invalid
 
-        @note  gsd_find_matching_chunk_name() calls gsd_flush() when the file is writable.
+        @note In read/write files gsd_find_matching_chunk_names() can only find names that have
+        been committed to the file with gsd_flush().
     */
     const char*
     gsd_find_matching_chunk_name(struct gsd_handle* handle, const char* match, const char* prev);

--- a/gsd/gsd.h
+++ b/gsd/gsd.h
@@ -291,9 +291,6 @@ extern "C"
         /// Mapped data chunk index
         struct gsd_index_buffer file_index;
 
-        /// Index entries to append to the current frame
-        struct gsd_index_buffer frame_index;
-
         /// Buffered index entries to append to the current frame
         struct gsd_index_buffer buffer_index;
 

--- a/gsd/gsd.h
+++ b/gsd/gsd.h
@@ -323,9 +323,6 @@ extern "C"
 
         /// Maximum write buffer size (bytes).
         uint64_t maximum_write_buffer_size;
-
-        /// Number of index entries to buffer before flushing.
-        uint64_t index_entries_to_buffer;
         };
 
     /** Specify a version.
@@ -650,34 +647,6 @@ extern "C"
           - GSD_ERROR_INVALID_ARGUMENT: size == 0
     */
     int gsd_set_maximum_write_buffer_size(struct gsd_handle* handle, uint64_t size);
-
-    /** Get the number of index entries to buffer.
-
-        @param handle Handle to an open GSD file
-
-        @pre *handle* was opened by gsd_open().
-
-        @return The number of index entries to buffer, or 0 on error.
-    */
-    uint64_t gsd_get_index_entries_to_buffer(struct gsd_handle* handle);
-
-    /** Set the number of index entries to buffer.
-
-        @param handle Handle to an open GSD file
-        @param number Number of index entries to buffer before automatically flushing in
-        `gsd_end_frame()` (must be greater than 0).
-
-        @pre *handle* was opened by gsd_open().
-
-        @note GSD may allocate more than this number of entries in the buffer, as needed to store
-        all index entries for the already buffered frames and the current frame.
-
-        @return
-          - GSD_SUCCESS (0) on success. Negative value on failure:
-          - GSD_ERROR_INVALID_ARGUMENT: *handle* is NULL
-          - GSD_ERROR_INVALID_ARGUMENT: number == 0
-    */
-    int gsd_set_index_entries_to_buffer(struct gsd_handle* handle, uint64_t number);
 
 #ifdef __cplusplus
     }

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -788,6 +788,12 @@ class HOOMDTrajectory:
 
         self.file.end_frame()
 
+        # This implementation must be able to read back frame 0, flush it.
+        # Allow the user to control when other frames are flushed.
+        if len(self) == 0:
+            self.flush()
+
+
     def truncate(self):
         """Remove all frames from the file."""
         self.file.truncate()

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -793,7 +793,6 @@ class HOOMDTrajectory:
         if len(self) == 0:
             self.flush()
 
-
     def truncate(self):
         """Remove all frames from the file."""
         self.file.truncate()

--- a/gsd/libgsd.pxd
+++ b/gsd/libgsd.pxd
@@ -128,5 +128,3 @@ cdef extern from "gsd.h" nogil:
     int gsd_upgrade(gsd_handle *handle)
     uint64_t gsd_get_maximum_write_buffer_size(gsd_handle* handle)
     int gsd_set_maximum_write_buffer_size(gsd_handle* handle, uint64_t size)
-    uint64_t gsd_get_index_entries_to_buffer(gsd_handle* handle)
-    int gsd_set_index_entries_to_buffer(gsd_handle* handle, uint64_t number)

--- a/gsd/test/test_fl.py
+++ b/gsd/test/test_fl.py
@@ -463,6 +463,8 @@ def test_truncate(tmp_path):
             f.write_chunk(name='data', data=data)
             f.end_frame()
 
+        f.flush()
+
         assert f.nframes == 10
 
         f.truncate()
@@ -550,6 +552,7 @@ def test_open(tmp_path):
     ) as f:
         f.write_chunk(name='chunk1', data=data)
         f.end_frame()
+        f.flush()
         f.read_chunk(0, name='chunk1')
 
     with gsd.fl.open(
@@ -571,6 +574,7 @@ def test_open(tmp_path):
     ) as f:
         f.write_chunk(name='chunk1', data=data)
         f.end_frame()
+        f.flush()
         f.read_chunk(0, name='chunk1')
 
     with gsd.fl.open(
@@ -604,6 +608,7 @@ def test_open(tmp_path):
         f.end_frame()
         f.read_chunk(0, name='chunk1')
         f.read_chunk(1, name='chunk1')
+        f.flush()
         f.read_chunk(2, name='chunk1')
 
 
@@ -1097,6 +1102,8 @@ def test_read_write(tmp_path, mode):
             f.write_chunk(name='data10', data=data)
             f.end_frame()
 
+        f.flush()
+
         for i in range(nframes):
             data1 = f.read_chunk(frame=i, name='data1')
             data10 = f.read_chunk(frame=i, name='data10')
@@ -1194,6 +1201,7 @@ def test_pending_index_entries(tmp_path):
         f.flush()
 
         f.end_frame()
+        f.flush()
 
         # All test chunks should be present in the file.
         for i in range(16):

--- a/gsd/test/test_fl.py
+++ b/gsd/test/test_fl.py
@@ -1239,20 +1239,48 @@ def test_flush(tmp_path, open_mode, n_flush):
 
 def test_maximum_write_buffer_size(tmp_path, open_mode):
     """Test maximum_write_buffer_size."""
+    file_name = tmp_path / 'test_maximum_write_buffer_size.gsd'
+
+    data_256 = numpy.full(shape=(256,), fill_value=1, dtype=numpy.uint8)
+    data_1024 = numpy.full(shape=(1024,), fill_value=2, dtype=numpy.uint8)
+
     with gsd.fl.open(
-        name=tmp_path / 'test_maximum_write_buffer_size.gsd',
+        name=file_name,
         mode=open_mode.write,
         application='test_maximum_write_buffer_size',
         schema='none',
         schema_version=[1, 2],
     ) as f:
         assert f.maximum_write_buffer_size > 0
-        f.maximum_write_buffer_size = 1024
-        assert f.maximum_write_buffer_size == 1024
 
         with pytest.raises(RuntimeError):
             f.maximum_write_buffer_size = 0
 
+        f.maximum_write_buffer_size = 1024
+        assert f.maximum_write_buffer_size == 1024
+
+        initial_size = os.path.getsize(file_name)
+        f.write_chunk(name="data", data=data_256)
+        assert os.path.getsize(file_name) == initial_size
+        f.end_frame()
+
+        f.write_chunk(name="data", data=data_256)
+        f.end_frame()
+        f.write_chunk(name="data", data=data_256)
+        f.end_frame()
+        f.write_chunk(name="data", data=data_256)
+        f.end_frame()
+        f.write_chunk(name="data", data=data_256)
+        assert os.path.getsize(file_name) == initial_size + 1024
+        f.end_frame()
+        f.write_chunk(name="data", data=data_1024)
+        assert os.path.getsize(file_name) == initial_size + 1024 + 256 + 1024
+        f.end_frame()
+
+        f.flush()
+        for i in range(5):
+            numpy.testing.assert_array_equal(f.read_chunk(i, "data"), data_256)
+        numpy.testing.assert_array_equal(f.read_chunk(5, "data"), data_1024)
 
 def test_file_exists_error():
     """Test that IO errors throw the correct Python Exception."""
@@ -1292,3 +1320,29 @@ def test_pending_index_entries(tmp_path):
         # All test chunks should be present in the file.
         for i in range(16):
             assert f.chunk_exists(name=str(i), frame=1)
+
+
+@pytest.mark.parametrize('flush', [False, True])
+def test_expand(tmp_path, open_mode, flush):
+    """Test index expansion."""
+    with gsd.fl.open(
+        name=tmp_path / 'test_expand.gsd',
+        mode=open_mode.write,
+        application='test_expand',
+        schema='none',
+        schema_version=[1, 2],
+    ) as f:
+        N_ENTRIES = 1024
+
+        for i in range(N_ENTRIES):
+            data = numpy.array([i], dtype=numpy.int64)
+            f.write_chunk(name="data", data=data)
+            f.end_frame()
+            if flush and (i & 0xf == 0):
+                f.flush()
+
+        f.flush()
+        for i in range(N_ENTRIES):
+            expected_data = numpy.array([i], dtype=numpy.int64)
+            read_data = f.read_chunk(frame=i, name='data')
+            numpy.testing.assert_array_equal(read_data, expected_data)

--- a/gsd/test/test_fl.py
+++ b/gsd/test/test_fl.py
@@ -752,7 +752,7 @@ def test_gsd_v1_read():
         chunk_names.sort()
         assert chunk_names == values_str
 
-    # test with the C implemantation
+    # test with the C implementation
     with gsd.fl.open(
         name=test_path / 'test_gsd_v1.gsd',
         mode='r',
@@ -893,7 +893,7 @@ def test_gsd_v1_write(tmp_path, open_mode):
 
         check_v1_file_read(f)
 
-    # test opening again with the C implemantation
+    # test opening again with the C implementation
     with gsd.fl.open(
         name=tmp_path / 'test_gsd_v1.gsd',
         mode=open_mode.read,
@@ -968,7 +968,7 @@ def test_gsd_v1_upgrade_write(tmp_path, open_mode):
 
         check_v1_file_read(f)
 
-    # test opening again with the C implemantation
+    # test opening again with the C implementation
     with gsd.fl.open(
         name=tmp_path / 'test_gsd_v1.gsd',
         mode=open_mode.read,
@@ -1162,7 +1162,7 @@ def test_maximum_write_buffer_size(tmp_path, open_mode):
 
 
 def test_file_exists_error():
-    """Test that IO errors throw the correct Python Excetion."""
+    """Test that IO errors throw the correct Python Exception."""
     with pytest.raises(FileExistsError):
         with gsd.fl.open(
             name=test_path / 'test_gsd_v1.gsd',

--- a/gsd/test/test_fl.py
+++ b/gsd/test/test_fl.py
@@ -1161,23 +1161,6 @@ def test_maximum_write_buffer_size(tmp_path, open_mode):
             f.maximum_write_buffer_size = 0
 
 
-def test_index_entries_to_buffer(tmp_path, open_mode):
-    """Test index_entries_to_buffer."""
-    with gsd.fl.open(
-        name=tmp_path / 'test_index_entries_to_buffer.gsd',
-        mode=open_mode.write,
-        application='test_index_entries_to_buffer',
-        schema='none',
-        schema_version=[1, 2],
-    ) as f:
-        assert f.index_entries_to_buffer > 0
-        f.index_entries_to_buffer = 1024
-        assert f.index_entries_to_buffer == 1024
-
-        with pytest.raises(RuntimeError):
-            f.index_entries_to_buffer = 0
-
-
 def test_file_exists_error():
     """Test that IO errors throw the correct Python Excetion."""
     with pytest.raises(FileExistsError):

--- a/gsd/test/test_fl.py
+++ b/gsd/test/test_fl.py
@@ -895,6 +895,7 @@ def test_gsd_v1_write(tmp_path, open_mode):
                 data = numpy.array([hash(value)], dtype=numpy.int64)
             f.write_chunk(name=str(value), data=data)
         f.end_frame()
+        f.flush()
 
         check_v1_file_read(f)
 
@@ -970,6 +971,7 @@ def test_gsd_v1_upgrade_write(tmp_path, open_mode):
                 data = numpy.array([hash(value)], dtype=numpy.int64)
             f.write_chunk(name=str(value), data=data)
         f.end_frame()
+        f.flush()
 
         check_v1_file_read(f)
 
@@ -1102,13 +1104,97 @@ def test_read_write(tmp_path, mode):
             f.write_chunk(name='data10', data=data)
             f.end_frame()
 
+        assert f.nframes == 0
         f.flush()
+        assert f.nframes == nframes
 
         for i in range(nframes):
             data1 = f.read_chunk(frame=i, name='data1')
             data10 = f.read_chunk(frame=i, name='data10')
             assert data1[0] == i
             assert data10[0] == i * 10
+
+
+@pytest.mark.parametrize('mode', ['w', 'x', 'a', 'r+'])
+def test_read_after_write(tmp_path, mode):
+    """Test that chunk names and data are not present until after flush."""
+    if mode[0] == 'r' or mode[0] == 'a':
+        with gsd.fl.open(
+            name=tmp_path / 'test_read_write.gsd',
+            mode='w',
+            application='test_read_write',
+            schema='none',
+            schema_version=[1, 2],
+        ):
+            pass
+
+    data = numpy.array([10], dtype=numpy.int64)
+    nframes = 1024
+
+    with gsd.fl.open(
+        name=tmp_path / 'test_read_write.gsd',
+        mode=mode,
+        application='test_read_write',
+        schema='none',
+        schema_version=[1, 2],
+    ) as f:
+        data[0] = 1
+        f.write_chunk(name='data1', data=data)
+        data[0] = 2
+        f.write_chunk(name='data2', data=data)
+        f.end_frame()
+
+        assert f.nframes == 0
+        assert not f.chunk_exists(frame=0, name='data1')
+        assert not f.chunk_exists(frame=0, name='data2')
+        assert len(f.find_matching_chunk_names('')) == 0
+        with pytest.raises(KeyError):
+            f.read_chunk(frame=0, name='data1')
+        with pytest.raises(KeyError):
+            f.read_chunk(frame=0, name='data2')
+
+        f.flush()
+
+        data[0] = 1
+        f.write_chunk(name='data1', data=data)
+        data[0] = 2
+        f.write_chunk(name='data2', data=data)
+        data[0] = 3
+        f.write_chunk(name='data3', data=data)
+        f.end_frame()
+
+        # frame 0 should now be available, but not frame 1
+        assert f.nframes == 1
+        assert f.chunk_exists(frame=0, name='data1')
+        assert f.chunk_exists(frame=0, name='data2')
+        assert len(f.find_matching_chunk_names('')) == 2
+        data1 = f.read_chunk(frame=0, name='data1')
+        assert data1[0] == 1
+        data2 = f.read_chunk(frame=0, name='data2')
+        assert data2[0] == 2
+
+        assert not f.chunk_exists(frame=1, name='data1')
+        assert not f.chunk_exists(frame=1, name='data2')
+        assert not f.chunk_exists(frame=1, name='data3')
+        with pytest.raises(KeyError):
+            f.read_chunk(frame=1, name='data1')
+        with pytest.raises(KeyError):
+            f.read_chunk(frame=1, name='data2')
+        with pytest.raises(KeyError):
+            f.read_chunk(frame=1, name='data3')
+
+        f.flush()
+        assert f.nframes == 2
+        assert f.chunk_exists(frame=1, name='data1')
+        assert f.chunk_exists(frame=1, name='data2')
+        assert f.chunk_exists(frame=1, name='data3')
+        assert len(f.find_matching_chunk_names('')) == 3
+        data1 = f.read_chunk(frame=1, name='data1')
+        assert data1[0] == 1
+        data2 = f.read_chunk(frame=1, name='data2')
+        assert data2[0] == 2
+        data3 = f.read_chunk(frame=1, name='data3')
+        assert data3[0] == 3
 
 
 @pytest.mark.parametrize('n_flush', [0, 1, 2])

--- a/gsd/test/test_fl.py
+++ b/gsd/test/test_fl.py
@@ -1335,7 +1335,7 @@ def test_expand(tmp_path, open_mode, flush):
         N_ENTRIES = 1024
 
         for i in range(N_ENTRIES):
-            data = numpy.array([i], dtype=numpy.int64)
+            data = numpy.array([i] * i, dtype=numpy.int64)
             f.write_chunk(name='data', data=data)
             f.end_frame()
             if flush and (i & 0xF == 0):
@@ -1343,6 +1343,6 @@ def test_expand(tmp_path, open_mode, flush):
 
         f.flush()
         for i in range(N_ENTRIES):
-            expected_data = numpy.array([i], dtype=numpy.int64)
+            expected_data = numpy.array([i] * i, dtype=numpy.int64)
             read_data = f.read_chunk(frame=i, name='data')
             numpy.testing.assert_array_equal(read_data, expected_data)

--- a/gsd/test/test_fl.py
+++ b/gsd/test/test_fl.py
@@ -1129,7 +1129,6 @@ def test_read_after_write(tmp_path, mode):
             pass
 
     data = numpy.array([10], dtype=numpy.int64)
-    nframes = 1024
 
     with gsd.fl.open(
         name=tmp_path / 'test_read_write.gsd',
@@ -1260,27 +1259,28 @@ def test_maximum_write_buffer_size(tmp_path, open_mode):
         assert f.maximum_write_buffer_size == 1024
 
         initial_size = os.path.getsize(file_name)
-        f.write_chunk(name="data", data=data_256)
+        f.write_chunk(name='data', data=data_256)
         assert os.path.getsize(file_name) == initial_size
         f.end_frame()
 
-        f.write_chunk(name="data", data=data_256)
+        f.write_chunk(name='data', data=data_256)
         f.end_frame()
-        f.write_chunk(name="data", data=data_256)
+        f.write_chunk(name='data', data=data_256)
         f.end_frame()
-        f.write_chunk(name="data", data=data_256)
+        f.write_chunk(name='data', data=data_256)
         f.end_frame()
-        f.write_chunk(name="data", data=data_256)
+        f.write_chunk(name='data', data=data_256)
         assert os.path.getsize(file_name) == initial_size + 1024
         f.end_frame()
-        f.write_chunk(name="data", data=data_1024)
+        f.write_chunk(name='data', data=data_1024)
         assert os.path.getsize(file_name) == initial_size + 1024 + 256 + 1024
         f.end_frame()
 
         f.flush()
         for i in range(5):
-            numpy.testing.assert_array_equal(f.read_chunk(i, "data"), data_256)
-        numpy.testing.assert_array_equal(f.read_chunk(5, "data"), data_1024)
+            numpy.testing.assert_array_equal(f.read_chunk(i, 'data'), data_256)
+        numpy.testing.assert_array_equal(f.read_chunk(5, 'data'), data_1024)
+
 
 def test_file_exists_error():
     """Test that IO errors throw the correct Python Exception."""
@@ -1336,9 +1336,9 @@ def test_expand(tmp_path, open_mode, flush):
 
         for i in range(N_ENTRIES):
             data = numpy.array([i], dtype=numpy.int64)
-            f.write_chunk(name="data", data=data)
+            f.write_chunk(name='data', data=data)
             f.end_frame()
-            if flush and (i & 0xf == 0):
+            if flush and (i & 0xF == 0):
                 f.flush()
 
         f.flush()

--- a/gsd/test/test_hoomd.py
+++ b/gsd/test/test_hoomd.py
@@ -734,6 +734,7 @@ def test_truncate(tmp_path):
     """Test the truncate API."""
     with gsd.hoomd.open(name=tmp_path / 'test_iteration.gsd', mode='w') as hf:
         hf.extend(create_frame(i) for i in range(20))
+        hf.flush()
 
         assert len(hf) == 20
         s = hf[10]  # noqa

--- a/scripts/benchmark-read.cc
+++ b/scripts/benchmark-read.cc
@@ -25,10 +25,8 @@ int main(int argc, char** argv) // NOLINT
     auto t1 = std::chrono::high_resolution_clock::now();
     gsd_open(&handle, "test.gsd", GSD_OPEN_READONLY);
     auto t2 = std::chrono::high_resolution_clock::now();
-    auto const open_time
-        = std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1);
+    auto const open_time = std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1);
     std::cout << "Time to open: " << open_time.count() / 1e-6 << " microseconds\n";
-
 
     size_t const n_frames = gsd_get_nframes(&handle);
     size_t n_read = n_frames;
@@ -65,14 +63,14 @@ int main(int argc, char** argv) // NOLINT
 
     t2 = std::chrono::high_resolution_clock::now();
 
-    auto const time_span
-        = std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1);
+    auto const time_span = std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1);
     double const time_per_key = time_span.count() / double(n_keys) / double(n_read);
     double const us_per_key = time_per_key / 1e-6;
 
     std::cout << "Sequential latency   : " << us_per_key << " microseconds/key.\n";
 
-    std::cout << "Sequential throughput: " << double(total_bytes) / 1024.0 / 1024.0 / time_span.count() << " MB/s\n";
-    
+    std::cout << "Sequential throughput: "
+              << double(total_bytes) / 1024.0 / 1024.0 / time_span.count() << " MB/s\n";
+
     gsd_close(&handle);
     }

--- a/scripts/benchmark-read.cc
+++ b/scripts/benchmark-read.cc
@@ -9,7 +9,7 @@
 
 int main(int argc, char** argv) // NOLINT
     {
-    const size_t n_keys = 40000;
+    const size_t n_keys = 2048;
     const size_t max_frames = 100;
     std::vector<char> data;
 
@@ -22,7 +22,14 @@ int main(int argc, char** argv) // NOLINT
         }
 
     gsd_handle handle;
+    auto t1 = std::chrono::high_resolution_clock::now();
     gsd_open(&handle, "test.gsd", GSD_OPEN_READONLY);
+    auto t2 = std::chrono::high_resolution_clock::now();
+    auto const open_time
+        = std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1);
+    std::cout << "Time to open: " << open_time.count() / 1e-6 << " microseconds\n";
+
+
     size_t const n_frames = gsd_get_nframes(&handle);
     size_t n_read = n_frames;
     if (n_read > max_frames)
@@ -33,8 +40,9 @@ int main(int argc, char** argv) // NOLINT
     std::cout << "Reading test.gsd with: " << n_keys << " keys and " << n_frames << " frames."
               << '\n';
 
-    auto t1 = std::chrono::high_resolution_clock::now();
+    t1 = std::chrono::high_resolution_clock::now();
 
+    size_t total_bytes = 0;
     for (size_t frame = 0; frame < n_read; frame++)
         {
         for (auto const& name : names)
@@ -45,18 +53,21 @@ int main(int argc, char** argv) // NOLINT
                 {
                 data.resize(e->N * e->M * gsd_sizeof_type((gsd_type)e->type));
                 }
+            total_bytes += e->N * e->M * gsd_sizeof_type((gsd_type)e->type);
             gsd_read_chunk(&handle, data.data(), e);
             }
         }
 
-    auto t2 = std::chrono::high_resolution_clock::now();
+    t2 = std::chrono::high_resolution_clock::now();
 
-    std::chrono::duration<double> const time_span
+    auto const time_span
         = std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1);
     double const time_per_key = time_span.count() / double(n_keys) / double(n_read);
+    double const us_per_key = time_per_key / 1e-6;
 
-    const double us = 1e-6;
-    std::cout << "Sequential read time: " << time_per_key / us << " microseconds/key." << '\n';
+    std::cout << "Sequential latency   : " << us_per_key << " microseconds/key.\n";
 
+    std::cout << "Sequential throughput: " << double(total_bytes) / 1024.0 / 1024.0 / time_span.count() << " MB/s\n";
+    
     gsd_close(&handle);
     }

--- a/scripts/benchmark-read.cc
+++ b/scripts/benchmark-read.cc
@@ -17,7 +17,7 @@ int main(int argc, char** argv) // NOLINT
     for (size_t i = 0; i < n_keys; i++)
         {
         std::ostringstream s;
-        s << "log/hpmc/integrate/Sphere/quantity/" << i;
+        s << "key " << i;
         names.push_back(s.str());
         }
 
@@ -49,6 +49,11 @@ int main(int argc, char** argv) // NOLINT
             {
             const gsd_index_entry* e;
             e = gsd_find_chunk(&handle, frame, name.c_str());
+            if (e == nullptr)
+                {
+                std::cout << "ERROR: Chunk `" << name << "` not found\n";
+                exit(1);
+                }
             if (data.empty())
                 {
                 data.resize(e->N * e->M * gsd_sizeof_type((gsd_type)e->type));

--- a/scripts/benchmark-write.cc
+++ b/scripts/benchmark-write.cc
@@ -4,7 +4,6 @@
 #include <sstream>
 #include <string>
 #include <vector>
-#include <fcntl.h>
 
 #ifdef _WIN32
 #include <io.h>
@@ -56,11 +55,6 @@ double benchmark(size_t buffer)
         gsd_end_frame(&handle);
         }
     gsd_flush(&handle);
-    #ifdef __APPLE__
-    fcntl(handle.fd, F_FULLFSYNC);
-    #else
-    fsync(handle.fd);
-    #endif
 
     auto t2 = std::chrono::high_resolution_clock::now();
 

--- a/scripts/benchmark-write.cc
+++ b/scripts/benchmark-write.cc
@@ -37,9 +37,6 @@ double benchmark(size_t buffer)
         names.push_back(s.str());
         }
 
-    // std::cout << "Writing test.gsd with: " << n_keys << " keys, " << n_frames << " frames, "
-    //           << "and " << key_size << " double(s) per key" << '\n';
-
     gsd_handle handle;
     gsd_create_and_open(&handle, "test.gsd", "app", "schema", 0, GSD_OPEN_APPEND, 0);
     gsd_set_maximum_write_buffer_size(&handle, buffer);
@@ -61,20 +58,11 @@ double benchmark(size_t buffer)
         = std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1);
     double const time_per_key = time_span.count() / double(n_keys) / double(n_frames);
 
-    // const double us = 1e-6;
-    // std::cout << "Write time: " << time_per_key / us << " microseconds/key." << '\n';
-    // std::cout << "Write time: " << time_per_key / us * n_keys << " microseconds/frame." << '\n';
-
     const double mb_per_second
         = double(key_size * 8 + static_cast<const size_t>(32) * static_cast<const size_t>(2))
           / 1048576.0 / time_per_key;
-    // std::cout << "MB/s: " << mb_per_second << " MB/s." << '\n';
 
     gsd_close(&handle);
-
-    // gsd_open(&handle, "test.gsd", GSD_OPEN_READONLY);
-    // std::cout << "Frames: " << gsd_get_nframes(&handle) << '\n';
-    // gsd_close(&handle);
 
     return mb_per_second;
     }

--- a/scripts/benchmark-write.cc
+++ b/scripts/benchmark-write.cc
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <fcntl.h>
 
 #ifdef _WIN32
 #include <io.h>
@@ -55,7 +56,11 @@ double benchmark(size_t buffer)
         gsd_end_frame(&handle);
         }
     gsd_flush(&handle);
+    #ifdef __APPLE__
+    fcntl(handle.fd, F_FULLFSYNC);
+    #else
     fsync(handle.fd);
+    #endif
 
     auto t2 = std::chrono::high_resolution_clock::now();
 

--- a/scripts/benchmark-write.cc
+++ b/scripts/benchmark-write.cc
@@ -83,7 +83,7 @@ double benchmark(size_t buffer)
 
 int main(int argc, char** argv) // NOLINT
     {
-    size_t buffer = 1;
+    size_t buffer = 65536;
 
     std::cout << "[";
     while (buffer <= 64 * 1024 * 1024)

--- a/scripts/benchmark-write.cc
+++ b/scripts/benchmark-write.cc
@@ -40,7 +40,6 @@ double benchmark(size_t buffer)
     // std::cout << "Writing test.gsd with: " << n_keys << " keys, " << n_frames << " frames, "
     //           << "and " << key_size << " double(s) per key" << '\n';
 
-
     gsd_handle handle;
     gsd_create_and_open(&handle, "test.gsd", "app", "schema", 0, GSD_OPEN_APPEND, 0);
     gsd_set_maximum_write_buffer_size(&handle, buffer);
@@ -88,7 +87,7 @@ int main(int argc, char** argv) // NOLINT
     while (buffer <= 64 * 1024 * 1024)
         {
         std::cout << "[";
-        std::cout << buffer << ", " << benchmark(buffer) << "]," <<std::endl;
+        std::cout << buffer << ", " << benchmark(buffer) << "]," << std::endl;
         buffer *= 2;
         }
     std::cout << "]" << std::endl;

--- a/scripts/benchmark-write.cc
+++ b/scripts/benchmark-write.cc
@@ -14,11 +14,13 @@
 
 #include "gsd.h"
 
-int main(int argc, char** argv) // NOLINT
+double benchmark(size_t buffer)
     {
-    const size_t n_keys = 16;
-    const size_t n_frames = 100;
-    const size_t key_size = static_cast<const size_t>(1024) * static_cast<const size_t>(1024);
+    const size_t n_keys = 2;
+    const size_t key_size = 2048;
+    const size_t target_file_size = 256 * 1024 * 1024;
+
+    const size_t n_frames = target_file_size / key_size / n_keys / sizeof(double);
 
     std::vector<double> data(key_size);
 
@@ -35,23 +37,16 @@ int main(int argc, char** argv) // NOLINT
         names.push_back(s.str());
         }
 
-    std::cout << "Writing test.gsd with: " << n_keys << " keys, " << n_frames << " frames, "
-              << "and " << key_size << " double(s) per key" << '\n';
+    // std::cout << "Writing test.gsd with: " << n_keys << " keys, " << n_frames << " frames, "
+    //           << "and " << key_size << " double(s) per key" << '\n';
+
+
     gsd_handle handle;
     gsd_create_and_open(&handle, "test.gsd", "app", "schema", 0, GSD_OPEN_APPEND, 0);
-    for (size_t frame = 0; frame < n_frames / 2; frame++)
-        {
-        for (auto const& name : names)
-            {
-            gsd_write_chunk(&handle, name.c_str(), GSD_TYPE_DOUBLE, key_size, 1, 0, data.data());
-            }
-        gsd_end_frame(&handle);
-        }
-    fsync(handle.fd);
+    gsd_set_maximum_write_buffer_size(&handle, buffer);
 
     auto t1 = std::chrono::high_resolution_clock::now();
-
-    for (size_t frame = 0; frame < n_frames / 2; frame++)
+    for (size_t frame = 0; frame < n_frames; frame++)
         {
         for (auto const& name : names)
             {
@@ -59,26 +54,43 @@ int main(int argc, char** argv) // NOLINT
             }
         gsd_end_frame(&handle);
         }
+    gsd_flush(&handle);
     fsync(handle.fd);
 
     auto t2 = std::chrono::high_resolution_clock::now();
 
     std::chrono::duration<double> const time_span
         = std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1);
-    double const time_per_key = time_span.count() / double(n_keys) / double(n_frames / double(2));
+    double const time_per_key = time_span.count() / double(n_keys) / double(n_frames);
 
-    const double us = 1e-6;
-    std::cout << "Write time: " << time_per_key / us << " microseconds/key." << '\n';
-    std::cout << "Write time: " << time_per_key / us * n_keys << " microseconds/frame." << '\n';
+    // const double us = 1e-6;
+    // std::cout << "Write time: " << time_per_key / us << " microseconds/key." << '\n';
+    // std::cout << "Write time: " << time_per_key / us * n_keys << " microseconds/frame." << '\n';
 
     const double mb_per_second
         = double(key_size * 8 + static_cast<const size_t>(32) * static_cast<const size_t>(2))
           / 1048576.0 / time_per_key;
-    std::cout << "MB/s: " << mb_per_second << " MB/s." << '\n';
+    // std::cout << "MB/s: " << mb_per_second << " MB/s." << '\n';
 
     gsd_close(&handle);
 
-    gsd_open(&handle, "test.gsd", GSD_OPEN_READONLY);
-    std::cout << "Frames: " << gsd_get_nframes(&handle) << '\n';
-    gsd_close(&handle);
+    // gsd_open(&handle, "test.gsd", GSD_OPEN_READONLY);
+    // std::cout << "Frames: " << gsd_get_nframes(&handle) << '\n';
+    // gsd_close(&handle);
+
+    return mb_per_second;
+    }
+
+int main(int argc, char** argv) // NOLINT
+    {
+    size_t buffer = 1;
+
+    std::cout << "[";
+    while (buffer <= 64 * 1024 * 1024)
+        {
+        std::cout << "[";
+        std::cout << buffer << ", " << benchmark(buffer) << "]," <<std::endl;
+        buffer *= 2;
+        }
+    std::cout << "]" << std::endl;
     }

--- a/scripts/benchmark-write.cc
+++ b/scripts/benchmark-write.cc
@@ -16,8 +16,8 @@
 
 double benchmark(size_t buffer)
     {
-    const size_t n_keys = 2048;
-    const size_t key_size = 2;
+    const size_t n_keys = 2;
+    const size_t key_size = 2048;
     const size_t target_file_size = 256 * 1024 * 1024;
 
     const size_t n_frames = target_file_size / key_size / n_keys / sizeof(double);

--- a/scripts/benchmark-write.cc
+++ b/scripts/benchmark-write.cc
@@ -82,7 +82,7 @@ double benchmark(size_t buffer)
 
 int main(int argc, char** argv) // NOLINT
     {
-    size_t buffer = 1024 * 1024;
+    size_t buffer = 1024;
 
     std::cout << "[";
     while (buffer <= 64 * 1024 * 1024)

--- a/scripts/benchmark-write.cc
+++ b/scripts/benchmark-write.cc
@@ -33,7 +33,7 @@ double benchmark(size_t buffer)
     for (size_t i = 0; i < n_keys; i++)
         {
         std::ostringstream s;
-        s << "log/hpmc/integrate/Sphere/quantity/" << i;
+        s << "key " << i;
         names.push_back(s.str());
         }
 

--- a/scripts/benchmark-write.cc
+++ b/scripts/benchmark-write.cc
@@ -18,7 +18,7 @@ double benchmark(size_t buffer)
     {
     const size_t n_keys = 2;
     const size_t key_size = 2048;
-    const size_t target_file_size = 256 * 1024 * 1024;
+    const size_t target_file_size = static_cast<size_t>(256) * 1024 * 1024;
 
     const size_t n_frames = target_file_size / key_size / n_keys / sizeof(double);
 
@@ -83,12 +83,12 @@ int main(int argc, char** argv) // NOLINT
     {
     size_t buffer = 1024;
 
-    std::cout << "[";
-    while (buffer <= 64 * 1024 * 1024)
+    std::cout << "[\n";
+    while (buffer <= static_cast<size_t>(64) * 1024 * 1024)
         {
         std::cout << "[";
-        std::cout << buffer << ", " << benchmark(buffer) << "]," << std::endl;
+        std::cout << buffer << ", " << benchmark(buffer) << "],\n";
         buffer *= 2;
         }
-    std::cout << "]" << std::endl;
+    std::cout << "]\n";
     }

--- a/scripts/benchmark-write.cc
+++ b/scripts/benchmark-write.cc
@@ -16,8 +16,8 @@
 
 double benchmark(size_t buffer)
     {
-    const size_t n_keys = 2;
-    const size_t key_size = 2048;
+    const size_t n_keys = 2048;
+    const size_t key_size = 2;
     const size_t target_file_size = 256 * 1024 * 1024;
 
     const size_t n_frames = target_file_size / key_size / n_keys / sizeof(double);
@@ -82,7 +82,7 @@ double benchmark(size_t buffer)
 
 int main(int argc, char** argv) // NOLINT
     {
-    size_t buffer = 65536;
+    size_t buffer = 1024 * 1024;
 
     std::cout << "[";
     while (buffer <= 64 * 1024 * 1024)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Base backwards compatible bug fixes on `trunk-patch`. -->
<!-- Base additional functionality on `trunk-minor`. -->
<!-- Base API incompatible changes on `trunk-major`. -->

## Description

<!-- Describe your changes in detail. -->
* Write data chunks to the file first in, first out.
* Flush the data chunk write buffer as needed when writing chunks, but buffer index entries indefinitely.
* Remove all implicit calls to `gsd_flush` except in `gsd_close`.
* Remove the no longer relevant `index_entries_to_buffer`.
* Change the default buffer to 1 MB.

These changes improve the streaming write performance when writing large files because there is no longer a need to sync when flushing the write buffer. The caller now gets explicit control of when the index buffer is written to disk. As a consequence, files open in read/write mode can no longer read chunks until after an explicit call to `gsd_flush`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
During a review of the GSD code, I discovered many problems:
* `fsync` does not behave the same on macOS as it does on Linux (see the comment for b6f94b6)
* There was a missing sync after writing the index.
* The frame_index/buffer_index code was needlessly complicated.

I fixed these problems. Unfortunately, this drastically reduced performance on macOS and Frontier. At the same time, users have found that the default buffer size of 64 MB is too large and they often call flush on every frame.

`flush` is now *more necessary* than it was before because it is never called implicitly (except on close). I plan to solve the user experience problem in HOOMD with an automatic flush based on a timer. Flushing based on the number of frames or bytes written kills performance (especially on macOS and Frontier), but a timer based solution will naturally spread the (relatively) fixed cost flushes evenly and can provide users with consistent behavior regardless of all other settings (e.g., new frames will appear in the file every 10 seconds).

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->
New unit tests cover many corner cases in the new implementation.

Here is benchmark-write performance as a function of buffer size on a variety of systems:
![2048](https://github.com/user-attachments/assets/cc113914-77b2-4779-8612-73727ca93f98)

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
- [x] I have added a change log entry to ``CHANGELOG.rst``.
