### PR TITLE
Fix nested indent in read_log

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,21 @@ Change Log
 <https://semver.org/>`_.
 
 
+
 4.x
 ---
+
+4.x.x (xxxx-xx-xx)
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Fixed:*
+
+* ``gsd.hoomd.read_log`` no longer iterates over the file more than necessary
+
+*Added:*
+
+* ``gsd.hoomd.read_log`` now accepts a "glob_pattern" filter to restrict the returned data
+
 
 4.1.0 (2025-09-30)
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,33 +7,34 @@ Change Log
 `GSD <https://github.com/glotzerlab/gsd>`_ releases follow `semantic versioning
 <https://semver.org/>`_.
 
-
-
 4.x
 ---
 
-4.x.x (xxxx-xx-xx)
-^^^^^^^^^^^^^^^^^^^^^^^^
+4.2.0 (xxxx-xx-xx)
+^^^^^^^^^^^^^^^^^^
 
 *Fixed:*
 
 * ``gsd.hoomd.read_log`` no longer iterates over the file more than necessary
+  (`#459 <https://github.com/glotzerlab/gsd/pull/459>`__).
 * Debug log entries are no longer duplicated
+  (`#459 <https://github.com/glotzerlab/gsd/pull/459>`__).
 
 *Added:*
 
 * ``gsd.hoomd.read_log`` now accepts a "glob_pattern" filter to restrict the returned data
-
+  (`#459 <https://github.com/glotzerlab/gsd/pull/459>`__).
 * ``debug`` attribute for ``gsd.fl.GSDFile``, which toggles debug logging for performance-sensitive methods
+  (`#459 <https://github.com/glotzerlab/gsd/pull/459>`__).
 
 
 4.1.0 (2025-09-30)
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Build with ``abi3`` for ``Python >=3.11``
-  (`#459 <https://github.com/glotzerlab/gsd/pull/459>`__).
+  (`#454 <https://github.com/glotzerlab/gsd/pull/454>`__).
 * Remove support for ``Python <3.11`` following NEP29
-  (`#459 <https://github.com/glotzerlab/gsd/pull/459>`__).
+  (`#454 <https://github.com/glotzerlab/gsd/pull/454>`__).
 
 4.0.0 (2025-06-26)
 ^^^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,10 +18,13 @@ Change Log
 *Fixed:*
 
 * ``gsd.hoomd.read_log`` no longer iterates over the file more than necessary
+* Debug log entries are no longer duplicated
 
 *Added:*
 
 * ``gsd.hoomd.read_log`` now accepts a "glob_pattern" filter to restrict the returned data
+
+* ``debug`` attribute for ``gsd.fl.GSDFile``, which toggles debug logging for performance-sensitive methods
 
 
 4.1.0 (2025-09-30)

--- a/gsd/fl.pyx
+++ b/gsd/fl.pyx
@@ -291,6 +291,9 @@ cdef class GSDFile:
         cdef int exclusive_create = 0
         cdef int overwrite = 0
 
+        #: bool: Enable or disable debug mode for logging.
+        self.debug = debug
+
         self.mode = mode
 
         if mode == 'w':
@@ -373,8 +376,7 @@ cdef class GSDFile:
                                    + self.schema)
 
         self.__is_open = True
-        #: bool: Enable or disable debug mode for logging.
-        self.debug = debug
+
 
     def close(self):
         """close()

--- a/gsd/fl.pyx
+++ b/gsd/fl.pyx
@@ -700,8 +700,6 @@ cdef class GSDFile:
         cdef int64_t c_frame
         c_frame = frame
 
-        logger.debug('chunk exists: ' + self.name + ' - ' + name)
-
         with nogil:
             index_entry = libgsd.gsd_find_chunk(&self.__handle, c_frame, c_name)
 

--- a/gsd/fl.pyx
+++ b/gsd/fl.pyx
@@ -249,6 +249,8 @@ cdef class GSDFile:
 
         nframes (int): Number of frames.
 
+        debug (bool): Whether to enable debug logging for the file. (Default ``True``)
+
     :py:class:`GSDFile` implements an object oriented class interface to the GSD
     file layer. Use :py:func:`open` to open a GSD file and obtain a
     :py:class:`GSDFile` instance. :py:class:`GSDFile` can be used as a context
@@ -269,8 +271,6 @@ cdef class GSDFile:
 
         schema_version (tuple[int, int]): Schema version number
             (major, minor).
-
-        debug (bool): Whether to enable debug logging for the file. (Default ``True``)
 
         nframes (int): Number of frames.
 

--- a/gsd/fl.pyx
+++ b/gsd/fl.pyx
@@ -270,6 +270,8 @@ cdef class GSDFile:
         schema_version (tuple[int, int]): Schema version number
             (major, minor).
 
+        debug (bool): Whether to enable debug logging for the file. (Default ``True``)
+
         nframes (int): Number of frames.
 
         maximum_write_buffer_size (int): The Maximum write buffer size (bytes).

--- a/gsd/fl.pyx
+++ b/gsd/fl.pyx
@@ -285,7 +285,8 @@ cdef class GSDFile:
                  mode,
                  application,
                  schema,
-                 schema_version):
+                 schema_version,
+                 debug=True):
         cdef libgsd.gsd_open_flag c_flags
         cdef int exclusive_create = 0
         cdef int overwrite = 0
@@ -372,6 +373,8 @@ cdef class GSDFile:
                                    + self.schema)
 
         self.__is_open = True
+        #: bool: Enable or disable debug mode for logging.
+        self.debug = debug
 
     def close(self):
         """close()
@@ -447,15 +450,12 @@ cdef class GSDFile:
 
         __raise_on_error(retval, self.name)
 
-    def end_frame(self, debug=True):
+    def end_frame(self):
         """end_frame()
 
         Complete writing the current frame. After calling :py:meth:`end_frame()`
         future calls to :py:meth:`write_chunk()` will write to the **next**
         frame in the file.
-
-        Args:
-            debug (bool): Whether to enable debug logging. (Default value: True)
 
         :py:meth:`end_frame()` does NOT write frames to the underlying file.
         Complete frames will be available to read from the file 1) after the
@@ -494,7 +494,7 @@ cdef class GSDFile:
         if not self.__is_open:
             raise ValueError("File is not open")
 
-        if debug:
+        if self.debug:
             logger.debug('end frame: ' + self.name)
 
         with nogil:
@@ -518,7 +518,7 @@ cdef class GSDFile:
 
         __raise_on_error(retval, self.name)
 
-    def write_chunk(self, name, data, debug=True):
+    def write_chunk(self, name, data):
         """write_chunk(name, data)
 
         Write a data chunk to the file. After writing all chunks in the
@@ -529,7 +529,6 @@ cdef class GSDFile:
             data: Data to write into the chunk. Must be a numpy
                   array, or array-like, with 2 or fewer
                   dimensions.
-            debug (bool): Whether to enable debug logging. (Default value: True)
 
         Warning:
             :py:meth:`write_chunk()` will implicitly converts array-like and
@@ -590,8 +589,6 @@ cdef class GSDFile:
                 logger.warning('implicit data copy when writing chunk: ' + name)
             data_array = data_array.view()
 
-
-
             if len(data_array.shape) > 2:
                 raise ValueError("GSD can only write 1 or 2 dimensional arrays: "
                                 + name)
@@ -635,7 +632,7 @@ cdef class GSDFile:
             else:
                 raise ValueError("invalid type for chunk: " + name)
 
-        if debug:
+        if self.debug:
             # Once we have the data pointer, the behavior should be identical
             # for all data types
             logger.debug('write chunk: ' + self.name + ' - ' + name)
@@ -711,7 +708,7 @@ cdef class GSDFile:
 
         return index_entry != NULL
 
-    def read_chunk(self, frame, name, debug=True):
+    def read_chunk(self, frame, name):
         """read_chunk(frame, name)
 
         Read a data chunk from the file and return it as a numpy array.
@@ -719,7 +716,6 @@ cdef class GSDFile:
         Args:
             frame (int): Index of the frame to read
             name (str): Name of the chunk
-            debug (bool): Whether to enable debug logging. (Default value: True)
 
         Returns:
             ``(N,M)`` or ``(N,)`` `numpy.ndarray` of ``type``: Data read from
@@ -820,7 +816,7 @@ cdef class GSDFile:
         else:
             raise ValueError("invalid type for chunk: " + name)
 
-        if debug:
+        if self.debug:
             logger.debug('read chunk: ' + self.name + ' - '
                          + str(frame) + ' - ' + name)
 

--- a/gsd/fl.pyx
+++ b/gsd/fl.pyx
@@ -277,8 +277,8 @@ cdef class GSDFile:
 
     cdef libgsd.gsd_handle __handle
     cdef bint __is_open
-    cdef str mode
     cdef bint debug
+    cdef str mode
     cdef str name
 
 

--- a/gsd/fl.pyx
+++ b/gsd/fl.pyx
@@ -274,6 +274,8 @@ cdef class GSDFile:
 
         nframes (int): Number of frames.
 
+        debug (bool): Whether to enable debug logging for the file.
+
         maximum_write_buffer_size (int): The Maximum write buffer size (bytes).
     """
 

--- a/gsd/fl.pyx
+++ b/gsd/fl.pyx
@@ -278,7 +278,9 @@ cdef class GSDFile:
     cdef libgsd.gsd_handle __handle
     cdef bint __is_open
     cdef str mode
+    cdef bint debug
     cdef str name
+
 
     def __init__(self,
                  name,

--- a/gsd/fl.pyx
+++ b/gsd/fl.pyx
@@ -447,12 +447,15 @@ cdef class GSDFile:
 
         __raise_on_error(retval, self.name)
 
-    def end_frame(self):
+    def end_frame(self, debug=True):
         """end_frame()
 
         Complete writing the current frame. After calling :py:meth:`end_frame()`
         future calls to :py:meth:`write_chunk()` will write to the **next**
         frame in the file.
+
+        Args:
+            debug (bool): Whether to enable debug logging. (Default value: True)
 
         :py:meth:`end_frame()` does NOT write frames to the underlying file.
         Complete frames will be available to read from the file 1) after the
@@ -491,7 +494,8 @@ cdef class GSDFile:
         if not self.__is_open:
             raise ValueError("File is not open")
 
-        logger.debug('end frame: ' + self.name)
+        if debug:
+            logger.debug('end frame: ' + self.name)
 
         with nogil:
             retval = libgsd.gsd_end_frame(&self.__handle)
@@ -514,7 +518,7 @@ cdef class GSDFile:
 
         __raise_on_error(retval, self.name)
 
-    def write_chunk(self, name, data):
+    def write_chunk(self, name, data, debug=True):
         """write_chunk(name, data)
 
         Write a data chunk to the file. After writing all chunks in the
@@ -525,6 +529,7 @@ cdef class GSDFile:
             data: Data to write into the chunk. Must be a numpy
                   array, or array-like, with 2 or fewer
                   dimensions.
+            debug (bool): Whether to enable debug logging. (Default value: True)
 
         Warning:
             :py:meth:`write_chunk()` will implicitly converts array-like and
@@ -630,9 +635,10 @@ cdef class GSDFile:
             else:
                 raise ValueError("invalid type for chunk: " + name)
 
-        # Once we have the data pointer, the behavior should be identical
-        # for all data types
-        logger.debug('write chunk: ' + self.name + ' - ' + name)
+        if debug:
+            # Once we have the data pointer, the behavior should be identical
+            # for all data types
+            logger.debug('write chunk: ' + self.name + ' - ' + name)
 
         cdef char * c_name
         name_e = name.encode('utf-8')
@@ -705,7 +711,7 @@ cdef class GSDFile:
 
         return index_entry != NULL
 
-    def read_chunk(self, frame, name):
+    def read_chunk(self, frame, name, debug=True):
         """read_chunk(frame, name)
 
         Read a data chunk from the file and return it as a numpy array.
@@ -713,6 +719,7 @@ cdef class GSDFile:
         Args:
             frame (int): Index of the frame to read
             name (str): Name of the chunk
+            debug (bool): Whether to enable debug logging. (Default value: True)
 
         Returns:
             ``(N,M)`` or ``(N,)`` `numpy.ndarray` of ``type``: Data read from
@@ -813,8 +820,9 @@ cdef class GSDFile:
         else:
             raise ValueError("invalid type for chunk: " + name)
 
-        logger.debug('read chunk: ' + self.name + ' - '
-                     + str(frame) + ' - ' + name)
+        if debug:
+            logger.debug('read chunk: ' + self.name + ' - '
+                         + str(frame) + ' - ' + name)
 
         # only read chunk if we have data
         if index_entry.N != 0 and index_entry.M != 0:

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -21,11 +21,11 @@ See Also:
 """
 
 import copy
+import fnmatch.filter as fnfilter
 import json
 import logging
 import warnings
 from collections import OrderedDict
-from fnmatch import fnfilter
 
 import numpy
 

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -1153,14 +1153,14 @@ def read_log(name: str, scalar_only=False, glob_pattern='*'):
                                                   scalar_only=True))
         df
 
+
     To read only logs from HOOMD-Blue's ``ThermodynamicQuantities``:
 
     .. ipython:: python
 
-        log = gsd.hoomd.read_log('log_example.gsd',
+        log = gsd.hoomd.read_log('log-example.gsd',
                                   glob_pattern="*ThermodynamicQuantities*")
         log.keys()
-
     """
     if not fl_imported:
         msg = 'file layer module is not available'

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -100,8 +100,6 @@ class ConfigurationData:
             Array attributes that are not contiguous numpy arrays will be
             replaced with contiguous numpy arrays of the appropriate type.
         """
-        logger.debug('Validating ConfigurationData')
-
         if self.box is not None:
             self.box = numpy.ascontiguousarray(self.box, dtype=numpy.float32)
             self.box = self.box.reshape([6])
@@ -207,8 +205,6 @@ class ParticleData:
             Array attributes that are not contiguous numpy arrays will be
             replaced with contiguous numpy arrays of the appropriate type.
         """
-        logger.debug('Validating ParticleData')
-
         if self.position is not None:
             self.position = numpy.ascontiguousarray(self.position, dtype=numpy.float32)
             self.position = self.position.reshape([self.N, 3])
@@ -328,8 +324,6 @@ class BondData:
             Array attributes that are not contiguous numpy arrays will be
             replaced with contiguous numpy arrays of the appropriate type.
         """
-        logger.debug('Validating BondData')
-
         if self.typeid is not None:
             self.typeid = numpy.ascontiguousarray(self.typeid, dtype=numpy.uint32)
             self.typeid = self.typeid.reshape([self.N])
@@ -389,8 +383,6 @@ class ConstraintData:
             Array attributes that are not contiguous numpy arrays will be
             replaced with contiguous numpy arrays of the appropriate type.
         """
-        logger.debug('Validating ConstraintData')
-
         if self.value is not None:
             self.value = numpy.ascontiguousarray(self.value, dtype=numpy.float32)
             self.value = self.value.reshape([self.N])
@@ -461,8 +453,6 @@ class Frame:
 
     def validate(self):
         """Validate all contained frame data."""
-        logger.debug('Validating Frame')
-
         self.configuration.validate()
         self.particles.validate()
         self.bonds.validate()
@@ -738,9 +728,8 @@ class HOOMDTrajectory:
         frame. If it is the same, do not write it out as it can be instantiated
         either from the value at the initial frame or the default value.
         """
-        logger.debug('Appending frame to hoomd trajectory: ' + str(self.file))
-
-        frame.validate()
+        if isinstance(frame, Frame):
+            frame.validate()
 
         # want the initial frame specified as a reference to detect if chunks
         # need to be written
@@ -760,7 +749,6 @@ class HOOMDTrajectory:
             container = getattr(frame, path)
             for name in container._default_value:
                 if self._should_write(path, name, frame):
-                    logger.debug('writing data chunk: ' + path + '/' + name)
                     data = getattr(container, name)
 
                     if name == 'N':
@@ -825,9 +813,6 @@ class HOOMDTrajectory:
             initial_container = getattr(self._initial_frame, path)
             initial_data = getattr(initial_container, name)
             if numpy.array_equal(initial_data, data):
-                logger.debug(
-                    'skipping data chunk, matches frame 0: ' + path + '/' + name
-                )
                 return False
 
         matches_default_value = False
@@ -841,7 +826,6 @@ class HOOMDTrajectory:
         if matches_default_value and not self._chunk_exists_frame_0.get(
             path + '/' + name, False
         ):
-            logger.debug('skipping data chunk, default value: ' + path + '/' + name)
             return False
 
         return True
@@ -873,8 +857,6 @@ class HOOMDTrajectory:
         """
         if idx >= len(self):
             raise IndexError
-
-        logger.debug('reading frame ' + str(idx) + ' from: ' + str(self.file))
 
         if self._initial_frame is None and idx != 0:
             self._read_frame(0)

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -1129,7 +1129,7 @@ def read_log(name: str, scalar_only=False, glob_pattern='*'):
     The log data includes :chunk:`configuration/step` and all matching
     :chunk:`log/user_defined`, :chunk:`log/bonds/user_defined`, and
     :chunk:`log/particles/user_defined` quantities in the file that
-    match the provided `glob_pattern`.
+    match the provided ``glob_pattern``.
 
     Returns:
         `dict`

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -1222,17 +1222,17 @@ def read_log(name, scalar_only=False):
                         tmp, (gsdfileobj.nframes, *tuple(1 for _ in tmp.shape))
                     )
 
-            for idx in range(1, gsdfileobj.nframes):
-                for key, item in logged_data_dict.items():
-                    if not gsdfileobj.chunk_exists(frame=idx, name=key):
-                        continue
-                    data = gsdfileobj.read_chunk(frame=idx, name=key)
-                    if (
-                        not isinstance(item.dtype, numpy.dtypes.StringDType)
-                        and len(item[idx].shape) == 0
-                    ):
-                        item[idx] = data[0]
-                    else:
-                        item[idx] = data
+        for idx in range(1, gsdfileobj.nframes):
+            for key, item in logged_data_dict.items():
+                if not gsdfileobj.chunk_exists(frame=idx, name=key):
+                    continue
+                data = gsdfileobj.read_chunk(frame=idx, name=key)
+                if (
+                    not isinstance(item.dtype, numpy.dtypes.StringDType)
+                    and len(item[idx].shape) == 0
+                ):
+                    item[idx] = data[0]
+                else:
+                    item[idx] = data
 
     return logged_data_dict

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -1153,14 +1153,6 @@ def read_log(name: str, scalar_only=False, glob_pattern='*'):
                                                   scalar_only=True))
         df
 
-
-    To read only logs from HOOMD-Blue's ``ThermodynamicQuantities``:
-
-    .. ipython:: python
-
-        log = gsd.hoomd.read_log('log-example.gsd',
-                                  glob_pattern="*ThermodynamicQuantities*")
-        log.keys()
     """
     if not fl_imported:
         msg = 'file layer module is not available'

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -21,11 +21,11 @@ See Also:
 """
 
 import copy
-import fnmatch.filter as fnfilter
 import json
 import logging
 import warnings
 from collections import OrderedDict
+from fnmatch import filter as fnfilter
 
 import numpy
 

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -1159,7 +1159,6 @@ def read_log(name: str, scalar_only=False, glob_pattern='*'):
 
         log = gsd.hoomd.read_log('log_example.gsd',
                                   glob_pattern="*ThermodynamicQuantities*")
-
         log.keys()
 
     """

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -25,6 +25,7 @@ import json
 import logging
 import warnings
 from collections import OrderedDict
+from fnmatch import fnfilter
 
 import numpy
 
@@ -1116,16 +1117,19 @@ def open(name, mode='r'):  # noqa: A001 - allow shadowing builtin open
     return HOOMDTrajectory(gsdfileobj)
 
 
-def read_log(name, scalar_only=False):
+def read_log(name: str, scalar_only=False, glob_pattern='*'):
     """Read log from a hoomd schema GSD file into a dict of time-series arrays.
 
     Args:
         name (str): File name to open.
         scalar_only (bool): Set to `True` to include only scalar log values.
+        glob_pattern (bool):
+            Apply a globbing wildcard filter to the log keys before reading.
 
     The log data includes :chunk:`configuration/step` and all matching
     :chunk:`log/user_defined`, :chunk:`log/bonds/user_defined`, and
-    :chunk:`log/particles/user_defined` quantities in the file.
+    :chunk:`log/particles/user_defined` quantities in the file that
+    match the provided `glob_pattern`.
 
     Returns:
         `dict`
@@ -1168,7 +1172,11 @@ def read_log(name, scalar_only=False):
         schema='hoomd',
         schema_version=[1, 4],
     ) as gsdfileobj:
-        logged_data_names = gsdfileobj.find_matching_chunk_names('log/')
+        logged_data_names = (
+            fnfilter(gsdfileobj.find_matching_chunk_names('log/'), glob_pattern)
+            if glob_pattern != '*'
+            else gsdfileobj.find_matching_chunk_names('log/')
+        )
         # Always log timestep associated with each log entry
         logged_data_names.insert(0, 'configuration/step')
         if len(logged_data_names) == 1:
@@ -1176,7 +1184,7 @@ def read_log(name, scalar_only=False):
                 'No logged data in file: ' + str(name), RuntimeWarning, stacklevel=2
             )
 
-        logged_data_dict = dict()
+        logged_data_dict: dict[str, numpy.ndarray] = {}
         for log in logged_data_names:
             log_exists_frame_0 = gsdfileobj.chunk_exists(frame=0, name=log)
             is_configuration_step = log == 'configuration/step'
@@ -1191,7 +1199,7 @@ def read_log(name, scalar_only=False):
                     if isinstance(tmp, str):
                         tmp = numpy.array([tmp], dtype=numpy.dtypes.StringDType)
 
-                if scalar_only and not tmp.shape[0] == 1:
+                if scalar_only and tmp.shape[0] != 1:
                     continue
                 if tmp.shape[0] == 1:
                     logged_data_dict[log] = numpy.full(
@@ -1206,9 +1214,10 @@ def read_log(name, scalar_only=False):
 
         for idx in range(1, gsdfileobj.nframes):
             for key, item in logged_data_dict.items():
-                if not gsdfileobj.chunk_exists(frame=idx, name=key):
-                    continue
-                data = gsdfileobj.read_chunk(frame=idx, name=key)
+                data = gsdfileobj.read_chunk(
+                    frame=idx if gsdfileobj.chunk_exists(frame=idx, name=key) else 0,
+                    name=key,
+                )
                 if (
                     not isinstance(item.dtype, numpy.dtypes.StringDType)
                     and len(item[idx].shape) == 0

--- a/gsd/hoomd.py
+++ b/gsd/hoomd.py
@@ -1152,6 +1152,16 @@ def read_log(name: str, scalar_only=False, glob_pattern='*'):
         df = pandas.DataFrame(gsd.hoomd.read_log('log-example.gsd',
                                                   scalar_only=True))
         df
+
+    To read only logs from HOOMD-Blue's ``ThermodynamicQuantities``:
+
+    .. ipython:: python
+
+        log = gsd.hoomd.read_log('log_example.gsd',
+                                  glob_pattern="*ThermodynamicQuantities*")
+
+        log.keys()
+
     """
     if not fl_imported:
         msg = 'file layer module is not available'


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Base backwards compatible bug fixes on `trunk-patch`. -->
<!-- Base additional functionality on `trunk-minor`. -->
<!-- Base API incompatible changes on `trunk-major`. -->

## Description

`gsd.hoomd.read_log` separately iterates over scalar and vector-valued keys. The previous implementation contained a bug that nested these loops, causing poor performance. This has been fixed. In addition, debug logging has been made optional in gsd.fl, via a flag in `cdef class GSDFile `. An additional glob_pattern key has been added to aid in processing read_log queries

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/gsd/blob/trunk-patch/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**GSD Contributor Agreement**](https://github.com/glotzerlab/gsd/blob/trunk-patch/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/credits.rst`) in the pull request source branch.
- [x] I have added a change log entry to ``CHANGELOG.rst``.
